### PR TITLE
Allowing dkim signing via ipv6

### DIFF
--- a/opendkim.conf
+++ b/opendkim.conf
@@ -2,6 +2,6 @@ Socket             inet:12301@localhost
 Mode               sv
 UMask              002
 Syslog             yes
-InternalHosts      0.0.0.0/0
+InternalHosts      0.0.0.0/0, ::/0
 KeyTable           refile:/etc/opendkim/KeyTable
 SigningTable       refile:/etc/opendkim/SigningTable


### PR DESCRIPTION
Currently, it is not possible to sign emails which arrive with ipv6.
This small fix makes sure that ipv6 addresses are allowed too.

I tested this fixed on two different configurations:
1. network with only ipv4 addresses
2. network with ipv4 and ipv6 addresses