### PR TITLE
run: set required permissions for OpenDKIM

### DIFF
--- a/run
+++ b/run
@@ -23,8 +23,12 @@ dkimConfig()
       txtFile=$DIR/$selector.txt
       if [ ! -f "$privateFile" ] ; then
         mkdir -p "$DIR"
-        (cd "$DIR" && opendkim-genkey --selector=$selector --domain=$domain && chown opendkim:opendkim $selector.private)
+        (cd "$DIR" && opendkim-genkey --selector=$selector --domain=$domain)
       fi
+
+      # Ensure strict permissions required by opendkim
+      chown opendkim:opendkim $DIR $privateFile
+      chmod 600 $privateFile
 
       echo "$selector._domainkey.$domain $domain:$selector:$privateFile" >> /etc/opendkim/KeyTable
       echo "*@$domain $selector._domainkey.$domain" >> /etc/opendkim/SigningTable


### PR DESCRIPTION
OpenDKIM by default requires strict permissions on both the directory
of the key files as well as the key files themselves.

If the DKIM key is volume mounted (e.g. not created by `run`), then it
may not have the correct permissions. To fix this, we can always reset
the permissions with chown each time `run` is invoked.

Alternatively, we could use `RequireSafeKeys false` in opendkim.conf
so that the mail is sent regardless of permissions, but this is a less
secure option.