### PR TITLE
Added `ca-certificates`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN \
     libsasl2-modules \
     opendkim \
     opendkim-tools \
+    ca-certificates \
     rsyslog && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Could you please add `ca-certificates` as it would be necessary to relay to any every service behind tls (eg. AWS SES)