### PR TITLE
run: improve automatic DKIM private key creation

### DIFF
--- a/run
+++ b/run
@@ -22,8 +22,9 @@ dkimConfig()
       privateFile="$domainDir/$selector.private"
       txtFile="$domainDir/$selector.txt"
       if [ ! -f "$privateFile" ] ; then
+        echo "No DKIM private key found for selector '$selector' in domain '$domain'. Generating one now..."
         mkdir -p "$domainDir"
-        (cd "$domainDir" && opendkim-genkey --selector=$selector --domain=$domain)
+        opendkim-genkey -D "$domainDir" --selector=$selector --domain=$domain
       fi
 
       # Ensure strict permissions required by opendkim


### PR DESCRIPTION
Run opendkim-genkey with the "-D" ("--directory") option instead of
changing directory manually in a bash subshell.

Also output an informational message when a DKIM private key is being
generated. This is useful to see, especially if you were expecting an
existing file to be found (e.g. if the wrong selector was used).