### PR TITLE
Chmod and chown whole opendkim key directory

### DIFF
--- a/run
+++ b/run
@@ -27,15 +27,15 @@ dkimConfig()
         opendkim-genkey -D "$domainDir" --selector=$selector --domain=$domain --append-domain
       fi
 
-      # Ensure strict permissions required by opendkim
-      chown opendkim:opendkim "$domainDir" "$privateFile"
-      chmod a=,u=rw "$privateFile"
-
       echo "$selector._domainkey.$domain $domain:$selector:$privateFile" >> /etc/opendkim/KeyTable
       echo "*@$domain $selector._domainkey.$domain" >> /etc/opendkim/SigningTable
       
       cat "$txtFile"
     done
+
+    # Ensure strict permissions required by opendkim
+    chown -R opendkim:opendkim "/etc/opendkim/keys"
+    chmod -R g=,o= "/etc/opendkim/keys"
 }
 
 # Unclean container stop might leave pid files around and rsyslogd seems


### PR DESCRIPTION
Looking at the source https://github.com/trusteddomainproject/OpenDKIM/blob/5c539587561785a66c1f67f720f2fb741f320785/opendkim/opendkim.c#L4695
it seems it will make sure all parents are secure which make sense.

Maybe fixes #14