### PR TITLE
ci.yml: add monthly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - '**'
   pull_request:
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   docker:


### PR DESCRIPTION
This will help keep the image up-to-date when there are infrequent pushes to the master branch.