### PR TITLE
GH Workflow - dynamic image name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,22 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Helper for custom repo name
+        id: reponame
+        run: |
+          if [ "${DOCKER_REPO}" != "" ]; then
+            echo ::set-output name=DOCKER_REPO::${DOCKER_REPO}
+          else
+            echo ::set-output name=DOCKER_REPO::${{ github.repository }}
+          fi
+        env:
+          DOCKER_REPO: "${{ secrets.DOCKER_REPO }}"
+      -
         name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: mwader/postfix-relay # list of Docker images to use as base name for tags
+          images: ${{ steps.reponame.outputs.DOCKER_REPO }} # list of Docker images to use as base name for tags
           tag-sha: true # add git short SHA as Docker tag
       -
         name: Set up QEMU


### PR DESCRIPTION
This will probably break your own GH workflow, because I see your github name doesn't match dockerhub. It just seemed better than hard-coded repo name