### PR TITLE
Added docker image version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - '**'
+    tags:
+      - '*'
   pull_request:
 
 jobs:
@@ -27,10 +29,17 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3
         with:
           images: ${{ steps.reponame.outputs.DOCKER_REPO }} # list of Docker images to use as base name for tags
-          tag-sha: true # add git short SHA as Docker tag
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=sha
+          flavor: |
+            latest=false
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
I plan to use the image for production and it's essential to be able to lock to specific version. I understand there's the SHA tag, but I would suggest more "standardised" naming, like 1.0.0, 1.0 and 1. Current SHA is kept, so no breaking change happens.

You can check result here:
https://hub.docker.com/repository/docker/veselahouba/postfix-relay/tags?page=1&ordering=last_updated
produced by git tag `1.0.0` (`v1.0.0` should work too)