### PR TITLE
Optional logging to file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN \
     ca-certificates \
     rsyslog && \
   apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* \
+    /etc/rsyslog.conf
 # Default config:
 # Open relay, trust docker links for firewalling.
 # Try to use TLS when sending to other smtp servers.
@@ -29,8 +30,9 @@ ENV \
   OPENDKIM_Syslog=yes \
   OPENDKIM_InternalHosts="0.0.0.0/0, ::/0" \
   OPENDKIM_KeyTable=refile:/etc/opendkim/KeyTable \
-  OPENDKIM_SigningTable=refile:/etc/opendkim/SigningTable
-COPY rsyslog.conf /etc/rsyslog.conf
+  OPENDKIM_SigningTable=refile:/etc/opendkim/SigningTable \
+  RSYSLOG_TIMESTAMP=no \
+  RSYSLOG_LOG_TO_FILE=no
 RUN mkdir -p /etc/opendkim/keys
 COPY run /root/
 VOLUME ["/var/lib/postfix", "/var/mail", "/var/spool/postfix", "/etc/opendkim/keys"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ smtp:
     - OPENDKIM_DOMAINS=smtp.domain.tld
 ```
 
+### Logging
+By default container only logs to stdout. If you also wish to log `mail.*` messages to file on persistent volume, you can do something like:
+
+```
+environment:
+  ...
+  - RSYSLOG_LOG_TO_FILE=yes
+  - RSYSLOG_TIMESTAMP=yes
+volumes:
+  - /your_local_path:/var/log/
+```
+
 ### Known issues
 
 #### I see `key data is not secure: /etc/opendkim/keys can be read or written by other users` error messages.

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,7 +1,0 @@
-# redirect /var/log/syslog to stdout
-$ModLoad imuxsock
-# log only tag and message
-$template noTimestampFormat,"%syslogtag%%msg%\n"
-$ActionFileDefaultTemplate noTimestampFormat
-$WorkDirectory /var/spool/rsyslog
-*.*;auth,authpriv.none /dev/stdout

--- a/run
+++ b/run
@@ -67,6 +67,28 @@ if [ ! -z "$OPENDKIM_DOMAINS" ] ; then
   service opendkim start
 fi
 service postfix start
+
+# Don't fiddle with existing config file (e.g. mounted from filesystem)
+if [ -e /etc/rsyslog.conf ]; then
+  echo "Skipping /etc/rsyslog.conf generating - file already exists"
+else
+  # Rsyslog base
+  cat <<'EOF' > /etc/rsyslog.conf
+$ModLoad imuxsock
+$WorkDirectory /var/spool/rsyslog
+*.*;auth,authpriv.none /dev/stdout
+EOF
+
+  if [ "${RSYSLOG_TIMESTAMP}" == 'no' ] ; then
+    echo '$template noTimestampFormat,"%syslogtag%%msg%\n"' >> /etc/rsyslog.conf
+    echo '$ActionFileDefaultTemplate noTimestampFormat' >> /etc/rsyslog.conf
+  fi
+
+  if [ "${RSYSLOG_LOG_TO_FILE}" == 'yes' ] ; then
+    echo 'mail.* -/var/log/mail.log' >> /etc/rsyslog.conf
+  fi
+fi
+
 rsyslogd -n &
 wait
 exit 0


### PR DESCRIPTION
Keeping default stdout in-place.

I moved the whole `rsyslog.conf` to `run`, because it would be confusing having half of file copied and second half generated.