### PR TITLE
Adding SASL Auth to Postfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN \
     procps \
     postfix \
     libsasl2-modules \
-	libpam-pwdfile \
-	sasl2-bin \
-	whois \
+    libpam-pwdfile \
+    sasl2-bin \
+    whois \
     opendkim \
     opendkim-tools \
     ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN \
     procps \
     postfix \
     libsasl2-modules \
+	libpam-pwdfile \
+	sasl2-bin \
+	whois \
     opendkim \
     opendkim-tools \
     ca-certificates \
@@ -32,7 +35,8 @@ ENV \
   OPENDKIM_KeyTable=refile:/etc/opendkim/KeyTable \
   OPENDKIM_SigningTable=refile:/etc/opendkim/SigningTable \
   RSYSLOG_TIMESTAMP=no \
-  RSYSLOG_LOG_TO_FILE=no
+  RSYSLOG_LOG_TO_FILE=no \
+  SASL_Passwds=""
 RUN mkdir -p /etc/opendkim/keys
 COPY run /root/
 VOLUME ["/var/lib/postfix", "/var/mail", "/var/spool/postfix", "/etc/opendkim/keys"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,31 @@ mydomain.com relay:[relay1.mydomain.com]:587
 ```
 and run `postmap /etc/postfix/transport`.
 
+### Relay Client Authentication
+The container includes [Postfix SASL](https://www.postfix.org/SASL_README.html) authentication options that are disabled by default.
+
+#### Example Basic Client PAM Auth
+First, create a passwd file.
+
+```
+echo "myuser:"`docker run --rm mwader/postfix-relay mkpasswd -m sha-512 "mypassword"` >> passwd_file
+```
+
+Then mount the passwd file and add the following postfix configs via enviromental variable.
+
+```
+volumes:
+  - /path/to/passwd_file:/etc/postfix/sasl/sasl_passwds
+environment:
+  - SASL_Passwds=/etc/postfix/sasl/sasl_passwds
+  - POSTFIX_cyrus_sasl_config_path=/etc/postfix/sasl
+  - POSTFIX_smtpd_sasl_local_domain=$myhostname
+  - POSTFIX_smtpd_sasl_auth_enable=yes
+  - POSTFIX_broken_sasl_auth_clients=yes
+  - POSTFIX_smtpd_sasl_security_options=noanonymous
+  - POSTFIX_smtpd_recipient_restrictions="permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination"
+```
+
 ### OpenDKIM variables
 
 OpenDKIM [configuration options](http://opendkim.org/opendkim.conf.5.html) can be set

--- a/run
+++ b/run
@@ -63,7 +63,7 @@ for e in ${!OPENDKIM_*} ; do
   echo "${e:9} ${!e}" >> /etc/opendkim.conf
 done
 
-trap "service postfix stop; service opendkim stop; pkill -TERM rsyslogd; service saslauthd stop" SIGTERM SIGINT
+trap "service postfix stop; service opendkim stop; pkill -TERM rsyslogd; pkill -TERM saslauthd" SIGTERM SIGINT
 if [ ! -z "$OPENDKIM_DOMAINS" ] ; then
   dkimConfig
   service opendkim start
@@ -80,8 +80,6 @@ EOF
   fi
   
   # Updating saslauthd config to work with chroot
-  sed -i 's|START=no|START=yes|' /etc/default/saslauthd
-  sed -i 's|OPTIONS="-c -m /var/run/saslauthd"|OPTIONS="-c -r -m /var/spool/postfix/var/run/saslauthd"|' /etc/default/saslauthd
   dpkg-statoverride --add root sasl 710 /var/spool/postfix/var/run/saslauthd
   
   # Giving postfix permission to use saslauthd
@@ -97,7 +95,8 @@ password        required        pam_deny.so
 EOF
   fi
   
-  service saslauthd start
+  mkdir -p /var/spool/postfix/var/run/saslauthd
+  saslauthd -c -r -a pam -m /var/spool/postfix/var/run/saslauthd &
 fi
 
 service postfix start

--- a/run
+++ b/run
@@ -63,7 +63,7 @@ for e in ${!OPENDKIM_*} ; do
   echo "${e:9} ${!e}" >> /etc/opendkim.conf
 done
 
-trap "service postfix stop; service opendkim stop; pkill -TERM rsyslogd" SIGTERM SIGINT
+trap "service postfix stop; service opendkim stop; pkill -TERM rsyslogd; service saslauthd stop" SIGTERM SIGINT
 if [ ! -z "$OPENDKIM_DOMAINS" ] ; then
   dkimConfig
   service opendkim start

--- a/run
+++ b/run
@@ -68,6 +68,39 @@ if [ ! -z "$OPENDKIM_DOMAINS" ] ; then
   dkimConfig
   service opendkim start
 fi
+
+# Checking for user specified passwd file
+if [ ! -z "$SASL_Passwds" ] || [ -e "/etc/pam.d/smtp"] ; then
+  # Creating auth settings file
+  if [ ! -e /etc/postfix/sasl/smtpd.conf ] ; then
+    cat <<'EOF' > /etc/postfix/sasl/smtpd.conf
+pwcheck_method: saslauthd
+mech_list: CRAM-MD5 DIGEST-MD5 LOGIN PLAIN
+EOF
+  fi
+  
+  # Updating saslauthd config to work with chroot
+  sed -i 's|START=no|START=yes|' /etc/default/saslauthd
+  sed -i 's|OPTIONS="-c -m /var/run/saslauthd"|OPTIONS="-c -r -m /var/spool/postfix/var/run/saslauthd"|' /etc/default/saslauthd
+  dpkg-statoverride --add root sasl 710 /var/spool/postfix/var/run/saslauthd
+  
+  # Giving postfix permission to use saslauthd
+  adduser postfix sasl
+  
+  # Creating PAM authentication profile
+  if [ ! -e "/etc/pam.d/smtp" ] ; then
+	echo "$SASL_Passwds"
+    cat <<EOF > /etc/pam.d/smtp
+auth            required        pam_pwdfile.so pwdfile=$SASL_Passwds
+account         required        pam_permit.so
+session         required        pam_permit.so
+password        required        pam_deny.so
+EOF
+  fi
+  
+  service saslauthd start
+fi
+
 service postfix start
 
 # Don't fiddle with existing config file (e.g. mounted from filesystem)

--- a/run
+++ b/run
@@ -70,7 +70,7 @@ if [ ! -z "$OPENDKIM_DOMAINS" ] ; then
 fi
 
 # Checking for user specified passwd file
-if [ ! -z "$SASL_Passwds" ] || [ -e "/etc/pam.d/smtp"] ; then
+if [ ! -z "$SASL_Passwds" ] ; then
   # Creating auth settings file
   if [ ! -e /etc/postfix/sasl/smtpd.conf ] ; then
     cat <<'EOF' > /etc/postfix/sasl/smtpd.conf
@@ -89,7 +89,6 @@ EOF
   
   # Creating PAM authentication profile
   if [ ! -e "/etc/pam.d/smtp" ] ; then
-	echo "$SASL_Passwds"
     cat <<EOF > /etc/pam.d/smtp
 auth            required        pam_pwdfile.so pwdfile=$SASL_Passwds
 account         required        pam_permit.so


### PR DESCRIPTION
Let me know what you think of these changes. I tried to follow your style as best as I could. Once the changes are accepted and merged to the public docker image I will most likely remove my repo. You can follow the process I was following [here](https://wiki.debian.org/PostfixAndSASL) and [here](https://seenthis.net/messages/522996). 

- Updates Dockerfile to install sasl binaries

libpam-pwdfile is used to read the passwd file, sasl2-bin is the actual service that does the client authentication, and whois includes mkpasswd which isn't strictly necessary but is useful to end users when creating their passwd files.

- Updates Readme with example of basic auth situation.

Includes a link to the official Postfix docs where this situation is covers for people who may want to modify. After that, an example is included with basic PAM auth backed by a file and how to generate the file. The number of env variables that need to be set isn't pretty but I figure that's better than having users try to go figure it out.

- Updates run file to configure SASL

I tried to follow your style here so feel free to make stylistic updates if I missed on anything. My changes will only run if the user passes the $SASL_Passwds variable since the passwds file must be generated by the user first. My changes then create the smtpd config file if needed, update the saslauthd service for postfix chroot, then update PAM to use the user's passwd file. saslauthd will not be run if the user doesn't specify a passwd file to save resources. Postfix needs to start after these changes.

