### PR TITLE
Update milter protocol to 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV \
   OPENDKIM_UMask=002 \
   OPENDKIM_Syslog=yes \
   OPENDKIM_InternalHosts="0.0.0.0/0, ::/0" \
-  OPENDKIM_KeyTable=/etc/opendkim/KeyTable \
+  OPENDKIM_KeyTable=refile:/etc/opendkim/KeyTable \
   OPENDKIM_SigningTable=refile:/etc/opendkim/SigningTable \
   RSYSLOG_TIMESTAMP=no \
   RSYSLOG_LOG_TO_FILE=no \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV \
   OPENDKIM_UMask=002 \
   OPENDKIM_Syslog=yes \
   OPENDKIM_InternalHosts="0.0.0.0/0, ::/0" \
-  OPENDKIM_KeyTable=refile:/etc/opendkim/KeyTable \
+  OPENDKIM_KeyTable=/etc/opendkim/KeyTable \
   OPENDKIM_SigningTable=refile:/etc/opendkim/SigningTable \
   RSYSLOG_TIMESTAMP=no \
   RSYSLOG_LOG_TO_FILE=no \

--- a/run
+++ b/run
@@ -3,7 +3,6 @@
 # DKIM config
 dkimConfig()
 {
-    postconf -e milter_protocol=6
     postconf -e milter_default_action=accept
     postconf -e smtpd_milters=inet:localhost:12301
 

--- a/run
+++ b/run
@@ -3,7 +3,7 @@
 # DKIM config
 dkimConfig()
 {
-    postconf -e milter_protocol=2
+    postconf -e milter_protocol=6
     postconf -e milter_default_action=accept
     postconf -e smtpd_milters=inet:localhost:12301
 


### PR DESCRIPTION
Seeing DKIM header signature failures which are fixed by setting Postfix parameter milter_protocol value to 6. Possibly related to: https://marc.info/?l=postfix-users&m=157746682807997&q=mbox .