### PR TITLE
Fix OpenDKIM KeyTable file type.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV \
   OPENDKIM_UMask=002 \
   OPENDKIM_Syslog=yes \
   OPENDKIM_InternalHosts="0.0.0.0/0, ::/0" \
-  OPENDKIM_KeyTable=refile:/etc/opendkim/KeyTable \
+  OPENDKIM_KeyTable=/etc/opendkim/KeyTable \
   OPENDKIM_SigningTable=refile:/etc/opendkim/SigningTable \
   RSYSLOG_TIMESTAMP=no \
   RSYSLOG_LOG_TO_FILE=no \


### PR DESCRIPTION
Running 'opendkim-testkey -vvv' inside the container results in an error, since the file '/etc/opendkim/KeyTable' is not a regular expression file type. Hence the associated config line should either lose the 'refile:' prefix or this be changed to 'file:' (default type).