### PR TITLE
Add DNSSEC trust anchor for OpenDKIM.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ENV \
   OPENDKIM_Mode=sv \
   OPENDKIM_UMask=002 \
   OPENDKIM_Syslog=yes \
+  OPENDKIM_TrustAnchorFile=/usr/share/dns/root.key \
   OPENDKIM_InternalHosts="0.0.0.0/0, ::/0" \
   OPENDKIM_KeyTable=/etc/opendkim/KeyTable \
   OPENDKIM_SigningTable=refile:/etc/opendkim/SigningTable \


### PR DESCRIPTION
Missing standard OpenDKIM base config. Possibly more of interest with DKIM verification than signing, but also gets rid of the key not secure error when running 'opendkim-testkey -vvv' inside the container to debug (which can confuse and lead people to think it means private key filesystem permissions instead of DNSSEC).