### PR TITLE
Replace deprecated MAINTAINER with an OCI authors label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # bump: debian-trixie-slim /FROM debian:(.*)/ docker:debian|/^trixie-.*-slim/|sort
 FROM debian:trixie-20260713-slim
-MAINTAINER Mattias Wadman mattias.wadman@gmail.com
+LABEL org.opencontainers.image.authors="Mattias Wadman <mattias.wadman@gmail.com>"
 
 RUN \
   apt-get update && \


### PR DESCRIPTION
MAINTAINER has been deprecated since Docker 1.13 and BuildKit reports it
as a warning (MaintainerDeprecated) on every build. The OCI image spec
equivalent is the org.opencontainers.image.authors annotation, which is
also what registries and tooling actually read.

No functional change: the value is carried over as-is.

---
_Generated by [Claude Code](https://claude.ai/code)_