### PR TITLE
ci: update outdated actions and drop the removed set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,22 +14,22 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Helper for custom repo name
         id: reponame
         run: |
           if [ "${DOCKER_REPO}" != "" ]; then
-            echo ::set-output name=DOCKER_REPO::${DOCKER_REPO}
+            echo "DOCKER_REPO=${DOCKER_REPO}" >> "${GITHUB_OUTPUT}"
           else
-            echo ::set-output name=DOCKER_REPO::${{ github.repository }}
+            echo "DOCKER_REPO=${{ github.repository }}" >> "${GITHUB_OUTPUT}"
           fi
         env:
           DOCKER_REPO: "${{ secrets.DOCKER_REPO }}"
       -
         name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ steps.reponame.outputs.DOCKER_REPO }} # list of Docker images to use as base name for tags
           tags: |
@@ -42,21 +42,21 @@ jobs:
             latest=false
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push master as latest
         if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
@@ -67,7 +67,7 @@ jobs:
       -
         name: Build and push branch or test PR
         if: github.ref != 'refs/heads/master'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - name: Setup python
         uses: actions/setup-python@v5


### PR DESCRIPTION
The `::set-output` workflow command was disabled by GitHub, so the
"Helper for custom repo name" step no longer sets the `DOCKER_REPO`
output and `docker/metadata-action` receives an empty `images` value.
Write to the `$GITHUB_OUTPUT` file instead, which is the supported
replacement.

While here, bump the actions that are still pinned to versions running
on Node 12/16 runtimes:

  actions/checkout            v2 -> v4  (ci.yml and test.yml)
  docker/metadata-action      v3 -> v5
  docker/setup-qemu-action    v1 -> v3
  docker/setup-buildx-action  v1 -> v3
  docker/login-action         v1 -> v3
  docker/build-push-action    v2 -> v6

No change to what is built, tagged or pushed.

---
_Generated by [Claude Code](https://claude.ai/code)_