### PR TITLE
Replace every "__" in POSTFIXMASTER_ names, as documented

### DIFF
--- a/run
+++ b/run
@@ -52,7 +52,7 @@ rm -f \
 # POSTFIX_var env -> postconf -e var=$POSTFIX_var
 for e in ${!POSTFIX_*} ; do postconf -e "${e:8}=${!e}" ; done
 # POSTFIXMASTER_var env -> postconf -Me var=$POSTFIXMASTER_var + replace __ with /
-for e in ${!POSTFIXMASTER_*} ; do v="${e:14}" && postconf -Me "${v/__/\/}=${!e}"; done
+for e in ${!POSTFIXMASTER_*} ; do v="${e:14}" && postconf -Me "${v//__/\/}=${!e}"; done
 # POSTMAP_var env value -> /etc/postfix/var
 for e in ${!POSTMAP_*} ; do echo "${!e}" > "/etc/postfix/${e:8}" && postmap "/etc/postfix/${e:8}"; done
 chown -R postfix:postfix /var/lib/postfix /var/mail /var/spool/postfix


### PR DESCRIPTION
The README states that "All double `__` symbols will be replaced with `/`", but the expansion uses ${v/__/\/}, which substitutes only the first occurrence.

For the service/type names postconf -M accepts, a single slash is all that can appear, so this is not reachable through documented usage; the change simply makes the code match the documented rule instead of relying on that invariant.

---
_Generated by [Claude Code](https://claude.ai/code)_