### PR TITLE
Add a HEALTHCHECK based on postfix status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,6 @@ RUN mkdir -p /etc/opendkim/keys
 COPY run /root/
 VOLUME ["/var/lib/postfix", "/var/mail", "/var/spool/postfix", "/etc/opendkim/keys"]
 EXPOSE 25
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD pgrep -x master
 CMD ["/root/run"]


### PR DESCRIPTION
Without a HEALTHCHECK the container is reported healthy as soon as the `run` wrapper is alive, even if the postfix master died right after start-up. That is the failure mode orchestrators are expected to react to, and it currently goes unnoticed until mail stops flowing.

The check is `pgrep -x master`, which is what `postfix status` boils down to but without its side effect: `postfix status` logs one line through syslog on every invocation, which at the default 30s interval adds roughly 2880 lines a day to a container whose entire logging story is stdout. Redirecting the healthcheck's output does not help, because postfix-script logs through syslog rather than through the command's stdout. procps is already installed, so no extra package is needed.

An SMTP banner probe on port 25 would test slightly more, but it logs a connect/disconnect pair on every interval, so it is noisier still.

Verified on the built image: the container reports healthy about 10s after start, three healthcheck intervals add zero lines to the container log, and killing the postfix master flips it to unhealthy after the configured three retries.

---
_Generated by [Claude Code](https://claude.ai/code) and reviewed by @tigerblue77_