### PR TITLE
Stop taking ownership of /var/mail on start-up

### DIFF
--- a/run
+++ b/run
@@ -55,7 +55,7 @@ for e in ${!POSTFIX_*} ; do postconf -e "${e:8}=${!e}" ; done
 for e in ${!POSTFIXMASTER_*} ; do v="${e:14}" && postconf -Me "${v/__/\/}=${!e}"; done
 # POSTMAP_var env value -> /etc/postfix/var
 for e in ${!POSTMAP_*} ; do echo "${!e}" > "/etc/postfix/${e:8}" && postmap "/etc/postfix/${e:8}"; done
-chown -R postfix:postfix /var/lib/postfix /var/mail /var/spool/postfix
+chown -R postfix:postfix /var/lib/postfix /var/spool/postfix
 
 # OPENDKIM_var env -> put "key value" line in /etc/opendkim.conf
 echo -n > /etc/opendkim.conf


### PR DESCRIPTION
The start-up script chowns /var/mail recursively to postfix, so every user mailbox in it changes owner on each container start. postfix's local(8) delivery agent refuses to write a mailbox that is not owned by the recipient, so local delivery breaks after the first restart:

  postfix/local: to=<root@localhost>, relay=local, dsn=4.2.0,
  status=deferred (cannot update mailbox /var/mail/root for user root. destination /var/mail/root is not owned by recipient)

postfix does not need to own the mailboxes: local(8) writes them with the privileges of the recipient, and /var/mail itself is already root:mail 2775 in the base image. Only /var/lib/postfix and /var/spool/postfix have to belong to postfix.

Verified against the published image: with a root:mail /var/mail/root, delivery to root@localhost is deferred with the error above before this change, and delivers 391 bytes after it, with the mailbox still owned by root:mail across a restart.

Closes #104

---
_Generated by [Claude Code](https://claude.ai/code)_