### PR TITLE
Declare volumes only for the queue and the DKIM keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV \
   SASL_Passwds=""
 RUN mkdir -p /etc/opendkim/keys
 COPY run /root/
-VOLUME ["/var/lib/postfix", "/var/mail", "/var/spool/postfix", "/etc/opendkim/keys"]
+VOLUME ["/var/spool/postfix", "/etc/opendkim/keys"]
 EXPOSE 25
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD pgrep -x master

--- a/README.md
+++ b/README.md
@@ -130,6 +130,39 @@ smtp:
     - OPENDKIM_DOMAINS=smtp.domain.tld
 ```
 
+### Volumes
+The image declares volumes for the two directories holding state that cannot be
+recreated:
+
+- `/var/spool/postfix` — the postfix queue. Mail that has been accepted but not
+  yet delivered lives here, so replacing a container while messages are queued
+  loses them unless the queue is persisted.
+- `/etc/opendkim/keys` — the DKIM private keys. If they are lost, new keys are
+  generated at the next start and the DNS records you published no longer match
+  (see [DKIM](#dkim)).
+
+Everything else postfix writes is regenerated at start-up and is deliberately
+not declared. `/var/lib/postfix` only holds a lock file and the TLS PRNG seed,
+and `/var/mail` only receives mail addressed to a local user, which is not what
+a relay is for.
+
+Note that declaring a volume is not by itself enough to preserve anything.
+Without an explicit mount docker creates an *anonymous* volume: `docker compose
+up` carries it over when it recreates a container, but a plain `docker rm` and
+`docker run` replaces it with an empty one. To keep the queue and the keys
+across container replacement, mount them yourself:
+
+```
+volumes:
+  - /your_local_path/spool:/var/spool/postfix
+  - /your_local_path/dkim-keys:/etc/opendkim/keys
+```
+
+Do not point two running containers at the same queue directory. Postfix's
+singleton lock lives in `/var/lib/postfix` rather than in the queue, so nothing
+prevents two masters from working on one queue and duplicating or corrupting
+mail.
+
 ### Logging
 By default container only logs to stdout. If you also wish to log `mail.*` messages to file on persistent volume, you can do something like:
 


### PR DESCRIPTION
/var/lib/postfix and /var/mail have been declared as volumes since the first commit, before opendkim was even in the image, as a blanket "not sure where state ends up" decision. Neither holds state worth keeping.

/var/lib/postfix is postfix's data_directory. In this image it only ever holds master.lock and prng_exch: the TLS session caches that would live there are disabled, since smtp/smtpd/lmtp_tls_session_cache_database are all empty, and tlsmgr(8) truncates them at every start anyway, so there is nothing to preserve. Declaring it also advertises the directory as persistable state, and mounting a shared volume there is exactly what postfix's singleton lock refuses: the second container fails to start with "fatal: mail system startup failed" and never becomes healthy.

/var/mail only receives mail addressed to a local user, which is not what a relay is for.

Both directories stay in the image and keep working, they are just no longer backed by an automatic anonymous volume. Dropping a VOLUME is not a regression for anyone mounting explicitly, since binds and named volumes behave identically with or without the declaration, and a VOLUME cannot be un-declared by a downstream image.

The README documented none of the four volumes, not even the queue, so document the two that remain, including that an anonymous volume is carried over by docker compose but not by docker rm plus docker run.

Verified on the built image: two volumes declared and two anonymous volumes created at run, container healthy, local delivery to /var/mail and master.lock in /var/lib/postfix both still working, existing test suite passes.

Closes #120 

---
_Generated by [Claude Code](https://claude.ai/code)_ and reviewed by @tigerblue77 