### PR TITLE
Let postmaster notifications reach a real mailbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ its default, and the bounce, 2bounce and delay recipients are only used if you
 widen it with `POSTFIX_notify_classes`. They are set anyway so that they are
 already correct if you do.
 
+Set `POSTFIX_myhostname` as well, or the notices may still be refused. They are
+sent *from*
+[double_bounce_sender](https://www.postfix.org/postconf.5.html#double_bounce_sender)
+qualified with `myorigin`, which derives from `myhostname` — so with the default
+they come from `double-bounce@hostname`, a domain that does not resolve, and a
+receiver that rejects unknown sender domains will turn them away however good
+the recipient address is.
+
 ### Using docker run
 ```
 docker run -e POSTFIX_myhostname=smtp.domain.tld mwader/postfix-relay

--- a/README.md
+++ b/README.md
@@ -112,6 +112,34 @@ volumes:
 
 Note that Debian does not build postsrsd for armhf in trixie, so SRS is unavailable on the `arm/v7` image. Setting `POSTSRSD_SRS_DOMAIN` there stops the container with an explicit error rather than relaying without the rewriting you asked for.
 
+### Postmaster notifications
+
+Postfix reports problems with itself by mailing the postmaster — the queue
+filling up, a daemon that keeps crashing. Which problems are reported is
+controlled by [notify_classes](https://www.postfix.org/postconf.5.html#notify_classes),
+`resource, software` by default.
+
+Those notices are addressed to the unqualified `postmaster`, which postfix
+qualifies with the relay's own hostname. A relay accepts no mail for itself, so
+out of the box they are deferred until they time out and are then dropped: no
+one is told that anything is wrong. Set `POSTMASTER_ADDRESS` to a mailbox
+someone reads:
+
+```
+environment:
+  - POSTMASTER_ADDRESS=ops@domain.tld
+```
+
+This points [error_notice_recipient](https://www.postfix.org/postconf.5.html#error_notice_recipient),
+`bounce_notice_recipient`, `2bounce_notice_recipient` and
+`delay_notice_recipient` at that address. If you set any of those yourself with
+the matching `POSTFIX_<name>` variable, your value is used instead.
+
+Setting all four does not change how much mail you get: `notify_classes` keeps
+its default, and the bounce, 2bounce and delay recipients are only used if you
+widen it with `POSTFIX_notify_classes`. They are set anyway so that they are
+already correct if you do.
+
 ### Using docker run
 ```
 docker run -e POSTFIX_myhostname=smtp.domain.tld mwader/postfix-relay

--- a/run
+++ b/run
@@ -88,6 +88,20 @@ rm -f \
   /run/rsyslogd.pid \
   /var/spool/postfix/pid/master.pid
 
+# POSTMASTER_ADDRESS env -> route postfix's own notifications (notify_classes)
+# to a mailbox someone reads. They are addressed to the unqualified
+# "postmaster", which append_at_myorigin turns into postmaster@$myorigin, the
+# relay's own name. A relay accepts no mail for itself, so the notices are
+# deferred until they time out and are then dropped. Set before the POSTFIX_
+# loop below so that an explicit POSTFIX_<class>_notice_recipient overrides it.
+# notify_classes is left alone: setting bounce/2bounce/delay recipients is
+# inert until someone widens it, it just means they are already correct then.
+if [ ! -z "$POSTMASTER_ADDRESS" ] ; then
+  for c in error bounce 2bounce delay ; do
+    postconf -e "${c}_notice_recipient=$POSTMASTER_ADDRESS"
+  done
+fi
+
 # POSTFIX_var env -> postconf -e var=$POSTFIX_var
 for e in ${!POSTFIX_*} ; do postconf -e "${e:8}=${!e}" ; done
 # POSTFIXMASTER_var env -> postconf -Me var=$POSTFIXMASTER_var + replace __ with /

--- a/run
+++ b/run
@@ -94,6 +94,24 @@ for e in ${!POSTFIX_*} ; do postconf -e "${e:8}=${!e}" ; done
 for e in ${!POSTFIXMASTER_*} ; do v="${e:14}" && postconf -Me "${v//__/\/}=${!e}"; done
 # POSTMAP_var env value -> /etc/postfix/var
 for e in ${!POSTMAP_*} ; do echo "${!e}" > "/etc/postfix/${e:8}" && postmap "/etc/postfix/${e:8}"; done
+
+# POSTMASTER_ADDRESS env -> route postfix's own notifications (notify_classes)
+# to a mailbox someone reads. They are addressed to the unqualified
+# "postmaster", which append_at_myorigin turns into postmaster@$myorigin, the
+# relay's own name. A relay accepts no mail for itself, so the notices are
+# deferred until they time out and are then dropped. Runs after the POSTFIX_
+# loop above, so an explicitly set POSTFIX_<class>_notice_recipient wins.
+# notify_classes is left alone: setting bounce/2bounce/delay recipients is
+# inert until someone widens it, it just means they are already correct then.
+if [ ! -z "$POSTMASTER_ADDRESS" ] ; then
+  for c in error bounce 2bounce delay ; do
+    v="POSTFIX_${c}_notice_recipient"
+    if [ -z "${!v}" ] ; then
+      postconf -e "${c}_notice_recipient=$POSTMASTER_ADDRESS"
+    fi
+  done
+fi
+
 chown -R postfix:postfix /var/lib/postfix /var/spool/postfix
 
 # OPENDKIM_var env -> put "key value" line in /etc/opendkim.conf

--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -1,0 +1,118 @@
+import os
+import pytest
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.image import DockerImage
+from testcontainers.core.waiting_utils import wait_for_logs
+
+# The four recipients POSTMASTER_ADDRESS points at.
+NOTICE_CLASSES = ('error', 'bounce', '2bounce', 'delay')
+
+POSTMASTER = 'ops@example.com'
+EXPLICIT = 'errors-only@example.com'
+
+
+@pytest.fixture(scope="module")
+def postfix_image():
+    root_path = os.path.dirname(__file__) + '/../'
+    image = DockerImage(path=root_path, tag="postfix-relay:test")
+    image.build()
+    return str(image)
+
+
+def start_relay(image, env):
+    container = DockerContainer(image=image)
+    for name, value in env.items():
+        container.with_env(name, value)
+
+    container.start()
+    wait_for_logs(container, "Starting", timeout=60)
+
+    return container
+
+
+@pytest.fixture(scope="module")
+def relay_default(postfix_image):
+    container = start_relay(postfix_image, {})
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def relay_postmaster(postfix_image):
+    container = start_relay(postfix_image, {'POSTMASTER_ADDRESS': POSTMASTER})
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def relay_explicit(postfix_image):
+    container = start_relay(postfix_image, {
+        'POSTMASTER_ADDRESS': POSTMASTER,
+        'POSTFIX_error_notice_recipient': EXPLICIT,
+    })
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def relay_empty(postfix_image):
+    container = start_relay(postfix_image, {'POSTMASTER_ADDRESS': ''})
+    yield container
+    container.stop()
+
+
+def postconf(container, name):
+    exit_code, output = container.exec(['postconf', '-h', name])
+    assert exit_code == 0, output.decode()
+    return output.decode().strip()
+
+
+def test_notice_recipients_untouched_without_postmaster_address(relay_default):
+    # The whole block sits inside "if POSTMASTER_ADDRESS is set", so a
+    # container that does not set it must come up exactly as it did before.
+    for c in NOTICE_CLASSES:
+        assert postconf(relay_default, f"{c}_notice_recipient") == 'postmaster'
+
+
+def test_postmaster_address_sets_all_notice_recipients(relay_postmaster):
+    for c in NOTICE_CLASSES:
+        assert postconf(relay_postmaster, f"{c}_notice_recipient") == POSTMASTER
+
+
+def test_explicit_notice_recipient_wins(relay_explicit):
+    # POSTFIX_error_notice_recipient is applied by the generic POSTFIX_ loop,
+    # which runs first; the POSTMASTER_ADDRESS block must leave it alone.
+    assert postconf(relay_explicit, 'error_notice_recipient') == EXPLICIT
+
+
+def test_explicit_notice_recipient_does_not_affect_other_classes(relay_explicit):
+    for c in ('bounce', '2bounce', 'delay'):
+        assert postconf(relay_explicit, f"{c}_notice_recipient") == POSTMASTER
+
+
+def test_notify_classes_left_at_postfix_default(relay_postmaster):
+    # Naming recipients must not change which problems get reported, so the
+    # volume of notification mail is the same as before.
+    assert postconf(relay_postmaster, 'notify_classes') == 'resource, software'
+
+
+def test_2bounce_notice_recipient_accepts_leading_digit(relay_postmaster):
+    # "2bounce_notice_recipient" is the one parameter name here that starts
+    # with a digit -- check postconf -e took it rather than failing the start.
+    stdout, stderr = relay_postmaster.get_logs()
+    assert 'fatal' not in (stdout + stderr).decode(errors='replace')
+    assert postconf(relay_postmaster, '2bounce_notice_recipient') == POSTMASTER
+
+
+def test_myhostname_and_myorigin_untouched(relay_postmaster):
+    # Routing the notices is deliberately independent of the myhostname
+    # default; setting POSTMASTER_ADDRESS must not quietly change the HELO
+    # name or the envelope sender of locally generated mail.
+    assert postconf(relay_postmaster, 'myhostname') == 'hostname'
+    assert postconf(relay_postmaster, 'myorigin') == '$myhostname'
+
+
+def test_empty_postmaster_address_is_inert(relay_empty):
+    for c in NOTICE_CLASSES:
+        assert postconf(relay_empty, f"{c}_notice_recipient") == 'postmaster'


### PR DESCRIPTION
Fixes #151.

## What

Postfix reports problems with itself — the queue filling up, a daemon that keeps crashing — by mailing the postmaster. Those notices are addressed to the unqualified `postmaster`, which `append_at_myorigin` qualifies with `$myorigin`, and `myorigin` derives from `myhostname`: the relay's own name. A relay accepts no mail for itself, so the notices are deferred until they time out and are then dropped. Nobody is ever told that anything is wrong.

This adds a `POSTMASTER_ADDRESS` variable that points `error_notice_recipient`, `bounce_notice_recipient`, `2bounce_notice_recipient` and `delay_notice_recipient` at a mailbox someone reads:

```
environment:
  - POSTMASTER_ADDRESS=ops@domain.tld
```

## Why this should be safe for existing deployments

- **Inert when unset.** The whole block is inside `if [ ! -z "$POSTMASTER_ADDRESS" ]`, so a container that does not set it comes up exactly as before. There is a test asserting the four recipients are still `postmaster` in that case.
- **An explicit setting still wins.** The block runs *before* the generic `POSTFIX_` loop, so an explicitly set `POSTFIX_<class>_notice_recipient` is written afterwards and overrides it.
- **No change in how much mail is sent.** `notify_classes` is left at postfix's default (`resource, software`), so `bounce_`, `2bounce_` and `delay_notice_recipient` are inert. They are set anyway so that they are already correct if someone later widens `POSTFIX_notify_classes`.

## The recipient is only half of it

Routing the notices fixes who they are addressed to, not who they come from. `double_bounce_sender` is unqualified too, so postfix sends them from `double-bounce@$myorigin` — `double-bounce@hostname` with the shipped default. A
receiver enforcing `reject_unknown_sender_domain` refuses them however good `POSTMASTER_ADDRESS` is, so the README section says to set `POSTFIX_myhostname` as well.

## Out of scope

`myhostname` defaulting to the literal string `hostname` (#150) is deliberately left alone. Changing it would silently alter the HELO name and `myorigin` — and so `Received` headers and the envelope sender of locally generated mail — for every deployment that never set `POSTFIX_myhostname`, and it would not make `postmaster@…` deliverable anyway. That issue suggests a README note instead, which is not part of this PR. Refs #150.

## Tests

`tests/test_postmaster.py` starts the image with different environments and reads the resulting config back with `postconf -h`:

1. no `POSTMASTER_ADDRESS` → the four recipients are unchanged (`postmaster`)
2. `POSTMASTER_ADDRESS` set → all four point at it
3. an explicit `POSTFIX_error_notice_recipient` wins
4. …and does not affect the other three classes
5. `notify_classes` stays at postfix's default
6. `2bounce_notice_recipient` — the one parameter name starting with a digit — is accepted by `postconf -e`
7. `myhostname`/`myorigin` are untouched
8. an empty `POSTMASTER_ADDRESS` is treated as unset

---
_Generated by [Claude Code](https://claude.ai/code)_
