### PR TITLE
Document that the image sets myhostname to a placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ using `POSTFIX_<name>` environment variables. See [Dockerfile](Dockerfile) for d
 configuration. You probably want to set `POSTFIX_myhostname` (the FQDN used by 220/HELO).
 
 Note that `POSTFIX_myhostname` will change the postfix option
-[myhostname](http://www.postfix.org/postconf.5.html#myhostname), which defaults
-to the placeholder `hostname` — the literal string, not the container's
-hostname. Set it to the FQDN clients and remote servers should see: it is used
-for the 220 greeting and HELO, and
+[myhostname](http://www.postfix.org/postconf.5.html#myhostname). The image ships
+`POSTFIX_myhostname=hostname`, so unless you set it yourself a running container
+ends up with the literal string `hostname` rather than the qualified name
+postfix would otherwise derive from `gethostname()`. Set it to the FQDN clients
+and remote servers should see: it is used for the 220 greeting and HELO, and
 [myorigin](http://www.postfix.org/postconf.5.html#myorigin) derives from it, so
 it also affects `Received` headers and the envelope sender of mail postfix
 generates itself.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ using `POSTFIX_<name>` environment variables. See [Dockerfile](Dockerfile) for d
 configuration. You probably want to set `POSTFIX_myhostname` (the FQDN used by 220/HELO).
 
 Note that `POSTFIX_myhostname` will change the postfix option
-[myhostname](http://www.postfix.org/postconf.5.html#myhostname).
+[myhostname](http://www.postfix.org/postconf.5.html#myhostname), which defaults
+to the placeholder `hostname` — the literal string, not the container's
+hostname. Set it to the FQDN clients and remote servers should see: it is used
+for the 220 greeting and HELO, and
+[myorigin](http://www.postfix.org/postconf.5.html#myorigin) derives from it, so
+it also affects `Received` headers and the envelope sender of mail postfix
+generates itself.
 
 You can modify master.cf using postconf with `POSTFIXMASTER_` variables. All double `__` symbols will be replaced with `/`. For example
 


### PR DESCRIPTION
Fixes #150.

`POSTFIX_myhostname` is set to `hostname` in the Dockerfile, and `run` turns that into `postconf -e myhostname=hostname`. There is no command substitution, so a running container ends up with the literal eight-character string — not the container's hostname, which is what the name suggests at a glance, and not the qualified name postfix would derive from `gethostname()` on its own (which is what `postconf -d` reports, since `-d` ignores `main.cf`).

This is documentation only, no behaviour change: it extends the existing note in **Postfix variables** to say what the default actually is and what it affects.

## Why not change the default

The issue goes through this in more detail, but briefly:

- changing it would alter the HELO name and `myorigin` for every deployment that never set `POSTFIX_myhostname` — a silent behaviour change for existing users; and
- it would not make anything deliverable anyway. The name postfix computes on its own (typically something under `.localdomain`) is no more routable than `hostname`.

So the value here is clarity rather than correctness, and a note buys that at no risk. If you would rather resolve #150 differently — using the real container hostname, or warning at start-up while the value is still the placeholder — this can be closed and I will send that instead.

## Relationship to #152

Independent, and they do not conflict: #152 adds a new section further down the README, this one edits a paragraph near the top. #152 mentions this default as the reason postmaster notices end up undeliverable, but deliberately does not touch it.

---
_Generated by [Claude Code](https://claude.ai/code)_
