### PR TITLE
Notice when a daemon the relay needs is not running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ ENV \
   RSYSLOG_LOG_TO_FILE=no \
   SASL_Passwds=""
 RUN mkdir -p /etc/opendkim/keys
-COPY run /root/
+COPY run healthcheck /root/
 VOLUME ["/var/spool/postfix", "/etc/opendkim/keys"]
 EXPOSE 25
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD pgrep -x master
+  CMD ["/root/healthcheck"]
 CMD ["/root/run"]

--- a/README.md
+++ b/README.md
@@ -198,6 +198,27 @@ environment:
 
 If configuration via environment variables is not flexible enough it's possible to configure rsyslog directly: `.conf` files in the `/etc/rsyslog.d` directory will be [sorted alphabetically](https://www.rsyslog.com/doc/v8-stable/rainerscript/include.html#file) and included into the primary configuration.
 
+### Health check
+
+The image ships a `HEALTHCHECK`, so `docker ps` reports whether the relay is
+actually able to work. It covers every daemon the container started, not only
+the postfix master, because a relay that has lost OpenDKIM keeps accepting mail
+and sends it unsigned:
+
+- postfix is running and listening on every `inet` service in `master.cf`, so a
+  submission port added with a `POSTFIXMASTER_` variable is checked too;
+- rsyslogd is running, otherwise mail is relayed without a trace;
+- OpenDKIM, PostSRSd and saslauthd are running when the environment asks for
+  them.
+
+Listening sockets are read from the kernel rather than connected to, so the
+check leaves nothing in the log.
+
+A daemon that fails to start at all stops the container instead of relaying
+mail without the signing or rewriting that was configured, and a daemon that
+later gives up on its own exits the container non-zero, so `restart:
+on-failure` brings it back.
+
 ### Timezone
 Wrong timestamps in log can be fixed by setting proper timezone.
 This parameter is handled by Debian base image.

--- a/healthcheck
+++ b/healthcheck
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# A relay that is up but no longer signing, rewriting or logging is worse than
+# one that is down: mail keeps leaving, unsigned or unlogged, and nothing says
+# so. The health check therefore covers every daemon "run" started, and looks
+# at postfix accepting connections rather than only at its master process.
+
+fail()
+{
+    echo "$1" >&2
+    exit 1
+}
+
+running()
+{
+    pgrep -x "$1" > /dev/null
+}
+
+# Listening sockets are read from the kernel: actually connecting every
+# interval would log a connect and a lost connection each time.
+listening()
+{
+    local hex proc=/proc/net/tcp
+
+    printf -v hex ':%04X' "$1"
+    if [ -r /proc/net/tcp6 ] ; then
+      proc="$proc /proc/net/tcp6"
+    fi
+
+    # State 0A is listening, and the local address column ends with the port.
+    awk -v port="$hex" '$4 == "0A" && index($2, port) { found = 1 }
+                        END { exit !found }' $proc
+}
+
+running master || fail "postfix master is not running"
+
+# Follow master.cf rather than assuming port 25, so a submission port added
+# with a POSTFIXMASTER_ variable is checked too and a service turned off with
+# maxproc 0 is not.
+for service in $(postconf -M | awk '$2 == "inet" && $7 != "0" { print $1 }') ; do
+  endpoint="${service##*:}"
+  port=$(getent services "$endpoint" | awk '{ sub("/.*", "", $2) ; print $2 }')
+  listening "${port:-$endpoint}" || fail "postfix is not listening on $service"
+done
+
+running rsyslogd || fail "rsyslogd is not running, mail is relayed unlogged"
+
+if [ -n "$OPENDKIM_DOMAINS" ] ; then
+  running opendkim || fail "opendkim is not running, mail is relayed unsigned"
+fi
+
+if [ -n "$POSTSRSD_SRS_DOMAIN" ] ; then
+  running postsrsd || fail "postsrsd is not running, envelope senders are not rewritten"
+fi
+
+if [ -n "$SASL_Passwds" ] ; then
+  running saslauthd || fail "saslauthd is not running, clients cannot authenticate"
+fi

--- a/run
+++ b/run
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+# "service ... start" returns as soon as start-stop-daemon has forked, so a
+# daemon that dies on its configuration does so after a successful start. Wait
+# for it to be there, rather than relaying mail without the signing or the
+# rewriting the container was asked for.
+startService()
+{
+    local name="$1" process="$2" try
+
+    service "$name" start
+    for try in 1 2 3 4 5 ; do
+      if pgrep -x "$process" > /dev/null ; then
+        return
+      fi
+      sleep 0.2
+    done
+
+    echo "$name did not start, refusing to relay without it." >&2
+    exit 1
+}
+
 # DKIM config
 dkimConfig()
 {
@@ -105,10 +125,10 @@ for e in ${!OPENDKIM_*} ; do
   echo "${e:9} ${!e}" >> /etc/opendkim.conf
 done
 
-trap "service postfix stop; service opendkim stop; service postsrsd stop; pkill -TERM rsyslogd; pkill -TERM saslauthd" SIGTERM SIGINT
+trap "stopping=1; service postfix stop; service opendkim stop; service postsrsd stop; pkill -TERM rsyslogd; pkill -TERM saslauthd" SIGTERM SIGINT
 if [ ! -z "$OPENDKIM_DOMAINS" ] ; then
   dkimConfig
-  service opendkim start
+  startService opendkim opendkim
 fi
 
 if [ ! -z "$POSTSRSD_SRS_DOMAIN" ] ; then
@@ -117,7 +137,7 @@ if [ ! -z "$POSTSRSD_SRS_DOMAIN" ] ; then
     exit 1
   fi
   srsConfig
-  service postsrsd start
+  startService postsrsd postsrsd
 fi
 
 # Checking for user specified passwd file
@@ -150,7 +170,7 @@ EOF
   saslauthd -c -r -a pam -m /var/spool/postfix/var/run/saslauthd &
 fi
 
-service postfix start
+startService postfix master
 
 # Don't fiddle with existing config file (e.g. mounted from filesystem)
 if [ -e /etc/rsyslog.conf ]; then
@@ -188,4 +208,13 @@ fi
 
 rsyslogd -n &
 wait
+
+# Reaching this without having been signalled means a daemon started here gave
+# up on its own. Exiting 0 would look like a clean stop and leave an
+# on-failure restart policy with nothing to act on.
+if [ -z "$stopping" ] ; then
+  echo "A daemon exited on its own, stopping the relay." >&2
+  exit 1
+fi
+
 exit 0

--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -6,13 +6,17 @@ from testcontainers.core.image import DockerImage
 from testcontainers.core.waiting_utils import wait_for_logs
 
 @pytest.fixture(scope="session")
-def postfix(shared_network):
+def postfix_image():
     root_path = os.path.dirname(__file__) + '/../../'
     image = DockerImage(path=root_path, tag="postfix-relay:test")
 
     image.build()
 
-    container = DockerContainer(image=str(image)) \
+    return str(image)
+
+@pytest.fixture(scope="session")
+def postfix(shared_network, postfix_image):
+    container = DockerContainer(image=postfix_image) \
         .with_network(shared_network) \
         .with_network_aliases('postfix') \
         .with_exposed_ports(25) \

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,114 @@
+import docker
+import pytest
+import time
+
+from testcontainers.core.container import DockerContainer
+
+HEALTHCHECK = "/root/healthcheck"
+SUBMISSION = "submission/inet=submission inet n - y - - smtpd"
+
+def start_relay(image, **env):
+    container = DockerContainer(image=image)
+    for name, value in env.items():
+        container.with_env(name, value)
+
+    container.start()
+    # Postfix is the last daemon "run" starts, so a passing health check is
+    # what "started" means here, and every test below breaks a relay that was
+    # known to be up.
+    run_healthcheck(container, expected=0, timeout=30)
+
+    return container
+
+def run_healthcheck(container, expected, timeout=10):
+    # A killed daemon takes a moment to actually go away, and docker retries
+    # the check anyway, so wait for the expected verdict instead of catching
+    # the container mid-signal.
+    deadline = time.monotonic() + timeout
+
+    while True:
+        exit_code, output = container.exec(HEALTHCHECK)
+        if exit_code == expected or time.monotonic() > deadline:
+            return exit_code, output.decode()
+        time.sleep(0.5)
+
+@pytest.fixture
+def signing_relay(postfix_image):
+    container = start_relay(postfix_image, OPENDKIM_DOMAINS='example.com')
+
+    yield container
+    container.stop()
+
+def test_relay_with_everything_running_is_healthy(signing_relay):
+    exit_code, _ = run_healthcheck(signing_relay, expected=0)
+
+    assert exit_code == 0
+
+def test_stopped_opendkim_is_unhealthy(signing_relay):
+    signing_relay.exec("pkill -x opendkim")
+
+    exit_code, output = run_healthcheck(signing_relay, expected=1)
+
+    assert exit_code == 1
+    assert 'relayed unsigned' in output
+
+def test_relay_stops_when_a_daemon_exits(postfix_image):
+    container = start_relay(postfix_image)
+    wrapped = container.get_wrapped_container()
+
+    try:
+        container.exec("pkill -x rsyslogd")
+
+        # Losing rsyslogd means relaying mail nobody can see afterwards, and
+        # exiting 0 would look like a clean stop to a restart policy.
+        assert wrapped.wait(timeout=30)['StatusCode'] == 1
+        assert 'A daemon exited on its own' in wrapped.logs().decode()
+    finally:
+        container.stop()
+
+def test_configured_but_unopened_port_is_unhealthy(postfix_image):
+    # A submission port is a named service in master.cf rather than a number,
+    # which the check has to resolve to know what to look for.
+    container = start_relay(postfix_image)
+
+    try:
+        # master.cf gains the service but master is not reloaded, so postfix
+        # keeps running while nothing answers on 587.
+        container.exec(["postconf", "-M", "-e", SUBMISSION])
+
+        exit_code, output = run_healthcheck(container, expected=1)
+        assert exit_code == 1
+        assert 'not listening on submission' in output
+
+        container.exec("postfix reload")
+
+        assert run_healthcheck(container, expected=0)[0] == 0
+    finally:
+        container.stop()
+
+def test_daemon_that_cannot_start_stops_the_container(postfix_image):
+    container = docker.from_env().containers.run(
+        postfix_image,
+        detach=True,
+        environment={
+            'OPENDKIM_DOMAINS': 'example.com',
+            # Rejected by opendkim when it reads its configuration
+            'OPENDKIM_NotARealSetting': '1',
+        })
+
+    try:
+        assert container.wait(timeout=60)['StatusCode'] == 1
+        assert 'opendkim did not start' in container.logs().decode()
+    finally:
+        container.remove(force=True)
+
+def test_stopping_the_container_is_still_a_clean_exit(postfix_image):
+    container = start_relay(postfix_image)
+    wrapped = container.get_wrapped_container()
+
+    try:
+        wrapped.stop()
+
+        assert wrapped.wait(timeout=30)['StatusCode'] == 0
+    finally:
+        container.stop()


### PR DESCRIPTION
The health check only looked at the postfix master process, and nothing looked at the other daemons at all. A container whose OpenDKIM has died keeps accepting mail and, because milter_default_action is accept, sends it unsigned past the DNS records that promise otherwise, while docker still reports it healthy. The same goes for rsyslogd, whose loss means relaying mail nobody can see afterwards, and for PostSRSd and saslauthd.

Three things change:

The health check moves into its own script and covers every daemon "run" started, deciding what to expect from the same environment variables that decided what to start. It also verifies postfix is listening rather than merely running, following master.cf so that a submission port added with a POSTFIXMASTER_ variable is checked too and a service turned off with maxproc 0 is not. The listening state is read from /proc/net/tcp instead of connecting, so the check does not log a connect and a lost connection every 30 seconds.

Daemons are started through a helper that waits for the process to be there. "service ... start" returns as soon as start-stop-daemon has forked, so a daemon that rejects its configuration dies after a successful start, and the container would otherwise run on and relay mail without the signing or the rewriting it was asked for.

Finally, a daemon exiting on its own is no longer reported as a clean stop. "wait" returning without a signal means something gave up, which now exits 1 with a message rather than 0, so an on-failure restart policy acts on it. Stopping the container is unchanged and still exits 0.

Tested on the built image: a relay with DKIM enabled reports healthy, and turns unhealthy with an explicit message once opendkim is killed; declaring a submission port without reloading postfix is caught as "not listening on submission" and clears after a reload; an opendkim configuration it refuses to parse stops the container with "opendkim did not start" instead of relaying unsigned; killing rsyslogd exits 1 instead of 0; docker stop still exits 0.