### PR TITLE
Stop rebuilding everything from scratch on every push

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -10,7 +10,7 @@ jobs:
   version_update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: wader/bump/action@master
         env:
           GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
       - '*'
   pull_request:
 
+# A new push makes the images an in-flight run would produce obsolete, except
+# on master where the run publishes latest.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -62,8 +68,10 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: mwader/postfix-relay:latest
+          tags: ${{ steps.reponame.outputs.DOCKER_REPO }}:latest
           labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       -
         name: Build and push branch or test PR
         if: github.ref != 'refs/heads/master'
@@ -75,3 +83,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
       - 'master'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   event_file:
     name: "Event File"


### PR DESCRIPTION
The build matrix is three platforms, two of which run under QEMU, and every run starts from an empty cache: the apt-get layer is emulated from scratch even when a pull request only touches the README. Buildx has a GitHub Actions cache backend for exactly this, so both build steps now read from and write to it and only rebuild the layers that actually changed.

Superseded runs are also cancelled now. Pushing twice to a branch used to leave the first run emulating an arm build whose images nobody would ever pull. Master is excluded, since that run publishes the latest tag.

Two other things noticed while in here:

The master build hardcodes mwader/postfix-relay:latest, which ignores the DOCKER_REPO secret the workflow otherwise honours through the reponame step: a fork building its own images would push to the upstream repository name instead of its own, and only fail because it has no credentials for it. It now uses the same repository name as every other tag.

The bump workflow checks out actions/checkout@master, an unpinned moving branch that runs in a job holding BUMP_TOKEN. Pinned to v4, like the other workflows.