### PR TITLE
Cover DKIM signing and client authentication with tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 pytest_plugins = [
+   "tests.fixtures.dkim",
    "tests.fixtures.mailpit",
    "tests.fixtures.postfix",
    "tests.fixtures.shared_network",

--- a/tests/fixtures/dkim.py
+++ b/tests/fixtures/dkim.py
@@ -1,0 +1,34 @@
+import pytest
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+from testcontainers.mailpit import MailpitContainer
+
+DOMAIN = 'example.com'
+SELECTOR = 'relay'
+
+@pytest.fixture(scope="session")
+def dkim_mailpit(shared_network):
+    container = MailpitContainer("axllent/mailpit:v1.27") \
+        .with_network(shared_network) \
+        .with_network_aliases('dkim-mailpit')
+
+    container.start()
+    yield container
+    container.stop()
+
+@pytest.fixture(scope="session")
+def signing_postfix(shared_network, postfix_image, dkim_mailpit):
+    container = DockerContainer(image=postfix_image) \
+        .with_network(shared_network) \
+        .with_network_aliases('signing-postfix') \
+        .with_exposed_ports(25) \
+        .with_env('POSTFIX_relayhost', 'dkim-mailpit:1025') \
+        .with_env('OPENDKIM_DOMAINS', f"{DOMAIN}={SELECTOR}")
+
+    container.start()
+
+    wait_for_logs(container, "Starting the Postfix mail system", timeout=30)
+
+    yield container
+    container.stop()

--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -6,13 +6,17 @@ from testcontainers.core.image import DockerImage
 from testcontainers.core.waiting_utils import wait_for_logs
 
 @pytest.fixture(scope="session")
-def postfix(shared_network):
+def postfix_image():
     root_path = os.path.dirname(__file__) + '/../../'
     image = DockerImage(path=root_path, tag="postfix-relay:test")
 
     image.build()
 
-    container = DockerContainer(image=str(image)) \
+    return str(image)
+
+@pytest.fixture(scope="session")
+def postfix(shared_network, postfix_image):
+    container = DockerContainer(image=postfix_image) \
         .with_network(shared_network) \
         .with_network_aliases('postfix') \
         .with_exposed_ports(25) \

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 testcontainers
 testcontainers[mailpit]
+dkimpy

--- a/tests/test_client_auth.py
+++ b/tests/test_client_auth.py
@@ -1,0 +1,78 @@
+import docker
+import pytest
+import smtplib
+
+from email.message import EmailMessage
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+USER = 'myuser'
+PASSWORD = 'mypassword'
+
+@pytest.fixture(scope="session")
+def passwd_file(postfix_image, tmp_path_factory):
+    # The way the README tells users to create it.
+    hashed = docker.from_env().containers.run(
+        postfix_image, ["mkpasswd", "-m", "sha-512", PASSWORD], remove=True)
+
+    path = tmp_path_factory.mktemp("sasl") / "passwd_file"
+    path.write_text(f"{USER}:{hashed.decode().strip()}\n")
+    path.chmod(0o644)
+
+    return path
+
+@pytest.fixture(scope="session")
+def authenticating_postfix(postfix_image, passwd_file):
+    # The configuration the README documents for client authentication, with
+    # relaying restricted to authenticated clients.
+    container = DockerContainer(image=postfix_image) \
+        .with_exposed_ports(25) \
+        .with_volume_mapping(str(passwd_file), '/etc/postfix/sasl/sasl_passwds', 'ro') \
+        .with_env('SASL_Passwds', '/etc/postfix/sasl/sasl_passwds') \
+        .with_env('POSTFIX_smtpd_sasl_auth_enable', 'yes') \
+        .with_env('POSTFIX_cyrus_sasl_config_path', '/etc/postfix/sasl') \
+        .with_env('POSTFIX_smtpd_sasl_security_options', 'noanonymous') \
+        .with_env('POSTFIX_smtpd_relay_restrictions', 'permit_sasl_authenticated,reject')
+
+    container.start()
+
+    wait_for_logs(container, "Starting the Postfix mail system", timeout=30)
+
+    yield container
+    container.stop()
+
+def connect(container):
+    return smtplib.SMTP(host=container.get_container_host_ip(),
+                        port=container.get_exposed_port(port=25))
+
+def message():
+    msg = EmailMessage()
+    msg['Subject'] = 'Authenticated'
+    msg['From'] = 'sender@example.com'
+    msg['To'] = 'receiver@example.com'
+    msg.set_content('Hello')
+
+    return msg
+
+def test_client_can_authenticate(authenticating_postfix):
+    with connect(authenticating_postfix) as smtp:
+        code, _ = smtp.login(USER, PASSWORD)
+
+        assert code == 235
+
+def test_wrong_password_is_rejected(authenticating_postfix):
+    with connect(authenticating_postfix) as smtp:
+        with pytest.raises(smtplib.SMTPAuthenticationError):
+            smtp.login(USER, 'not the password')
+
+def test_authenticated_client_may_relay(authenticating_postfix):
+    with connect(authenticating_postfix) as smtp:
+        smtp.login(USER, PASSWORD)
+
+        assert smtp.send_message(message()) == {}
+
+def test_unauthenticated_client_may_not_relay(authenticating_postfix):
+    with connect(authenticating_postfix) as smtp:
+        with pytest.raises(smtplib.SMTPRecipientsRefused):
+            smtp.send_message(message())

--- a/tests/test_dkim.py
+++ b/tests/test_dkim.py
@@ -1,0 +1,64 @@
+import dkim
+import re
+import smtplib
+import time
+import requests
+
+from email.message import EmailMessage
+
+from tests.fixtures.dkim import DOMAIN, SELECTOR
+
+def published_record(container):
+    # opendkim-genkey writes the record as a BIND fragment, split over quoted
+    # strings the way a zone file wants it. Put it back together as the DNS
+    # answer a verifier would get.
+    _, output = container.exec(f"cat /etc/opendkim/keys/{DOMAIN}/{SELECTOR}.txt")
+
+    return "".join(re.findall(r'"([^"]*)"', output.decode())).encode()
+
+def relayed_message(mailpit, timeout=30):
+    api_url = f"{mailpit.get_base_api_url()}/api/v1"
+    deadline = time.monotonic() + timeout
+
+    while True:
+        messages = requests.get(f"{api_url}/messages").json()['messages']
+        if messages:
+            raw = requests.get(f"{api_url}/message/{messages[0]['ID']}/raw").content
+            # Line endings have to be what was signed for the body hash to
+            # match, whatever the store and the transport did with them.
+            return re.sub(rb'\r?\n', b'\r\n', raw)
+        if time.monotonic() > deadline:
+            raise AssertionError("no message was relayed")
+        time.sleep(0.5)
+
+def test_relayed_mail_is_signed(dkim_mailpit, signing_postfix):
+    msg = EmailMessage()
+    msg['Subject'] = 'Signed'
+    msg['From'] = f"sender@{DOMAIN}"
+    msg['To'] = 'receiver@example.org'
+    msg.set_content('Hello')
+
+    with smtplib.SMTP(host=signing_postfix.get_container_host_ip(),
+                      port=signing_postfix.get_exposed_port(port=25)) as smtp:
+        smtp.send_message(msg)
+
+    raw = relayed_message(dkim_mailpit)
+    signature = re.search(rb'^DKIM-Signature:(.*(?:\r\n[ \t].*)*)', raw, re.MULTILINE)
+
+    assert signature, "message was relayed without a DKIM-Signature header"
+    assert f"d={DOMAIN}".encode() in signature.group(1)
+    assert f"s={SELECTOR}".encode() in signature.group(1)
+
+    # And it verifies against the record the container told the operator to
+    # publish, which is the part that decides whether receivers accept it.
+    record = published_record(signing_postfix)
+
+    assert dkim.verify(raw, dnsfunc=lambda name, timeout=5: record)
+
+def test_private_key_is_only_readable_by_opendkim(signing_postfix):
+    # OpenDKIM refuses keys other users can read, and says so in the log
+    # instead of signing.
+    _, output = signing_postfix.exec(
+        f"stat -c %U:%G:%a /etc/opendkim/keys/{DOMAIN}/{SELECTOR}.private")
+
+    assert output.decode().strip() == 'opendkim:opendkim:600'


### PR DESCRIPTION
The two features an operator is most likely to get wrong, and the two whose breakage is hardest to notice, had no tests at all. A relay that stops signing keeps delivering mail, and a relay that stops enforcing authentication keeps accepting it: in both cases the suite stayed green while the image did the wrong thing.

DKIM is tested end to end rather than by looking for a header: the relayed message is verified cryptographically against the record the container printed for the operator to publish, which is what actually decides whether a receiver accepts the signature. It also covers the OPENDKIM_DOMAINS=<domain>=<selector> syntax and the private key permissions OpenDKIM insists on before it will sign.

Client authentication is tested through the configuration the README documents, including the mkpasswd invocation it tells users to run: the right password authenticates, a wrong one does not, an authenticated client may relay, and an unauthenticated one is refused.

Tested on the built image: seven tests pass, including the existing one. dkimpy is added to the test requirements for the signature verification.