### PR TITLE
Document how to keep the relay from relaying for everyone

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ and remote servers should see: it is used for the 220 greeting and HELO, and
 it also affects `Received` headers and the envelope sender of mail postfix
 generates itself.
 
+The image keeps Debian's `inet_protocols = ipv4`, so it neither accepts
+connections nor delivers mail over IPv6. Set `POSTFIX_inet_protocols=all` if
+your docker network has IPv6, or recipients you send to are IPv6 only.
+
 You can modify master.cf using postconf with `POSTFIXMASTER_` variables. All double `__` symbols will be replaced with `/`. For example
 
 ### Postfix master.cf variables
@@ -78,6 +82,53 @@ environment:
   - POSTFIX_smtpd_sasl_security_options=noanonymous
   - POSTFIX_smtpd_relay_restrictions=permit_sasl_authenticated,reject
 ```
+
+### Securing the relay
+
+The default configuration is an open relay that relies on docker networking for
+protection: anything that can reach port 25 can send mail through it, to
+anyone. That is fine while the port is only reachable from other containers on
+the same docker network, and it is why the port should not be published unless
+something outside docker really has to reach it.
+
+If it does, stop relaying for the whole world first, either by restricting who
+may relay by address:
+
+```
+environment:
+  # Whatever your docker network actually is
+  - POSTFIX_mynetworks=127.0.0.0/8,172.16.0.0/12
+```
+
+or by requiring authentication, using the setup described above and refusing
+everyone else:
+
+```
+environment:
+  - POSTFIX_smtpd_relay_restrictions=permit_sasl_authenticated,reject
+```
+
+Clients that authenticate should also be able to do it over an encrypted
+connection, otherwise the password crosses the network in the clear. Mount a
+certificate and its key, and point postfix at them:
+
+```
+volumes:
+  - /your_local_path/cert.pem:/etc/postfix/tls/cert.pem:ro
+  - /your_local_path/key.pem:/etc/postfix/tls/key.pem:ro
+environment:
+  - POSTFIX_smtpd_tls_cert_file=/etc/postfix/tls/cert.pem
+  - POSTFIX_smtpd_tls_key_file=/etc/postfix/tls/key.pem
+  # "may" advertises STARTTLS, "encrypt" refuses clients that do not use it
+  - POSTFIX_smtpd_tls_security_level=may
+  # Never accept credentials over an unencrypted connection
+  - POSTFIX_smtpd_tls_auth_only=yes
+```
+
+Mail leaving the relay is already sent over TLS whenever the receiving server
+offers it (`POSTFIX_smtp_tls_security_level=may`). Set it to `encrypt` when
+relaying through a provider, where an unencrypted connection is a
+misconfiguration rather than the only option.
 
 ### OpenDKIM variables
 

--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -6,13 +6,17 @@ from testcontainers.core.image import DockerImage
 from testcontainers.core.waiting_utils import wait_for_logs
 
 @pytest.fixture(scope="session")
-def postfix(shared_network):
+def postfix_image():
     root_path = os.path.dirname(__file__) + '/../../'
     image = DockerImage(path=root_path, tag="postfix-relay:test")
 
     image.build()
 
-    container = DockerContainer(image=str(image)) \
+    return str(image)
+
+@pytest.fixture(scope="session")
+def postfix(shared_network, postfix_image):
+    container = DockerContainer(image=postfix_image) \
         .with_network(shared_network) \
         .with_network_aliases('postfix') \
         .with_exposed_ports(25) \

--- a/tests/test_client_tls.py
+++ b/tests/test_client_tls.py
@@ -1,0 +1,61 @@
+import docker
+import pytest
+import smtplib
+import ssl
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+@pytest.fixture(scope="session")
+def certificate(postfix_image, tmp_path_factory):
+    path = tmp_path_factory.mktemp("tls")
+
+    # The image carries openssl, so the certificate an operator would generate
+    # is generated the same way here.
+    docker.from_env().containers.run(
+        postfix_image,
+        ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-noenc",
+         "-days", "1", "-subj", "/CN=smtp.example.com",
+         "-keyout", "/tls/key.pem", "-out", "/tls/cert.pem"],
+        volumes={str(path): {'bind': '/tls', 'mode': 'rw'}},
+        remove=True)
+
+    return path
+
+@pytest.fixture(scope="session")
+def encrypting_postfix(postfix_image, certificate):
+    # The configuration the README documents for encrypting client connections.
+    container = DockerContainer(image=postfix_image) \
+        .with_exposed_ports(25) \
+        .with_volume_mapping(str(certificate), '/etc/postfix/tls', 'ro') \
+        .with_env('POSTFIX_smtpd_tls_cert_file', '/etc/postfix/tls/cert.pem') \
+        .with_env('POSTFIX_smtpd_tls_key_file', '/etc/postfix/tls/key.pem') \
+        .with_env('POSTFIX_smtpd_tls_security_level', 'may') \
+        .with_env('POSTFIX_smtpd_tls_auth_only', 'yes')
+
+    container.start()
+
+    wait_for_logs(container, "Starting the Postfix mail system", timeout=30)
+
+    yield container
+    container.stop()
+
+def test_clients_can_start_tls(encrypting_postfix):
+    context = ssl.create_default_context()
+    # The certificate is self signed, which is what this checks nothing about.
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+
+    with smtplib.SMTP(host=encrypting_postfix.get_container_host_ip(),
+                      port=encrypting_postfix.get_exposed_port(port=25)) as smtp:
+        smtp.ehlo()
+
+        assert smtp.has_extn('starttls')
+
+        code, _ = smtp.starttls(context=context)
+
+        assert code == 220
+
+        smtp.ehlo()
+
+        assert smtp.does_esmtp


### PR DESCRIPTION
The README warns once, at the top, that the default configuration is an open relay, and then never says what to do about it. Everything needed is there -- mynetworks, the SASL setup, the postfix TLS settings -- but an operator publishing port 25 has to work out for themselves which parts to combine, and the failure mode of getting it wrong is being found by spammers.

The new section says it in one place: restrict who may relay by address or require authentication, and encrypt the connections that carry the password, with the configuration to do each. It also mentions setting the outgoing security level to encrypt when relaying through a provider, where an unencrypted connection is a misconfiguration rather than the only option.

The image also keeps Debian's inet_protocols = ipv4, which is worth saying where the postfix variables are described: on a docker network with IPv6 the relay is simply not reachable, and IPv6-only recipients cannot be delivered to, with nothing in the configuration hinting at why.

Tested on the built image: the documented TLS configuration is now covered by a test that generates a certificate the way an operator would, mounts it, and checks a client can STARTTLS. The rest of the suite passes unchanged.