### PR TITLE
Keep one POSTMASTER_ADDRESS block, not two

### DIFF
--- a/run
+++ b/run
@@ -129,23 +129,6 @@ for e in ${!POSTFIXMASTER_*} ; do v="${e:14}" && postconf -Me "${v//__/\/}=${!e}
 # POSTMAP_var env value -> /etc/postfix/var
 for e in ${!POSTMAP_*} ; do echo "${!e}" > "/etc/postfix/${e:8}" && postmap "/etc/postfix/${e:8}"; done
 
-# POSTMASTER_ADDRESS env -> route postfix's own notifications (notify_classes)
-# to a mailbox someone reads. They are addressed to the unqualified
-# "postmaster", which append_at_myorigin turns into postmaster@$myorigin, the
-# relay's own name. A relay accepts no mail for itself, so the notices are
-# deferred until they time out and are then dropped. Runs after the POSTFIX_
-# loop above, so an explicitly set POSTFIX_<class>_notice_recipient wins.
-# notify_classes is left alone: setting bounce/2bounce/delay recipients is
-# inert until someone widens it, it just means they are already correct then.
-if [ ! -z "$POSTMASTER_ADDRESS" ] ; then
-  for c in error bounce 2bounce delay ; do
-    v="POSTFIX_${c}_notice_recipient"
-    if [ -z "${!v}" ] ; then
-      postconf -e "${c}_notice_recipient=$POSTMASTER_ADDRESS"
-    fi
-  done
-fi
-
 chown -R postfix:postfix /var/lib/postfix /var/spool/postfix
 
 # OPENDKIM_var env -> put "key value" line in /etc/opendkim.conf


### PR DESCRIPTION
The commit that moved the notice recipients before the POSTFIX_ loop added the block there instead of moving it, so "run" now configures them twice: once unconditionally before the loop, and once after it for every class whose POSTFIX_<class>_notice_recipient is unset.

The result is the same either way -- the second pass only ever rewrites what the first one already set to the same value -- so this is dead code rather than a behaviour change, but the two comments now contradict each other about where the block belongs and which one wins, which is exactly the kind of thing the next reader has to work out from scratch.

The one before the loop is kept, as its commit intended: it lets an explicit POSTFIX_<class>_notice_recipient override POSTMASTER_ADDRESS by being applied after it.

Tested on the built image: the eight postmaster tests pass unchanged.