### PR TITLE
Say why the container has to run as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,22 @@ ensuring safe permissions on private keys.
 
 A workaround is to disable the check using a `OPENDKIM_RequireSafeKeys=no` environment variable.
 
+### I set `user:` in my compose file and the container fails with `/bin/bash: /root/run: Permission denied`.
+
+The container has to start as root. `/root` is `0700` and the entrypoint lives
+there, so another user cannot even read the script — the message reads like a
+broken file mode, but it is the intended one. A readable entrypoint would not
+get much further: postfix refuses to run as anyone else, with `the postfix
+command is reserved for the superuser`. See
+[What runs as root, and what to take away](#what-runs-as-root-and-what-to-take-away)
+for what the root processes do, and for the capabilities to drop instead.
+
+Setting `user:` to avoid ownership surprises on mounted directories does not
+help either: whatever `user:` says, the container hands the DKIM keys to
+`opendkim` and the queue to `postfix` on every start, because that is what
+those daemons require. Mount the directories and let the container set them
+up; on the host they will show the uids those daemons have inside it.
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- TESTING -->


### PR DESCRIPTION
Issue #89 is three years old and the only thing the image tells that user is `/bin/bash: /root/run: Permission denied`, which reads like a broken file mode rather than an answer. It is not: `/root` is `0700` and `COPY run healthcheck /root/` puts the entrypoint there, so another user cannot even read the script, and postfix would refuse anyway with `the postfix command is reserved for the superuser`.

Documented under Troubleshooting, beside the OpenDKIM entry, together with the reason setting `user:` is not a way around ownership on mounted directories: whatever `user:` says, the container hands the DKIM keys to `opendkim` (`run:54`) and the queue to `postfix` (`run:132`) on every start, because that is what those daemons require.

What the root processes actually do, and the capabilities worth dropping instead of changing the user, are covered by [What runs as root, and what to take away](https://github.com/wader/postfix-relay#what-runs-as-root-and-what-to-take-away), which landed in #170 after this branch was written. The entry links there rather than restating it, so the two do not drift apart.

Verified on the built image when the branch was written: `docker run --user 1000:1000` fails with the message above, and `postfix start` run as uid 1000 with a readable entrypoint fails with the superuser error. The change is documentation only — nothing outside `README.md` is touched.

Closes #89