### PR TITLE
Bump artifact actions to v5 to drop deprecated Node.js 20

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Download and Extract Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Event File
         path: ${{ github.event_path }}
@@ -40,7 +40,7 @@ jobs:
       
       - name: Upload Test Results
         if: (!cancelled())
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test Results
           path: |


### PR DESCRIPTION
`actions/download-artifact@v4` and `actions/upload-artifact@v4` run on Node.js 20, which GitHub Actions has deprecated. v5 of both actions runs on Node.js 24 and keeps the same multi-artifact download layout, so the `Event File` and `Test Results` artifact paths are unchanged.

Fixes #163