### PR TITLE
Update remaining GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -10,7 +10,7 @@ jobs:
   version_update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: wader/bump/action@master
         env:
           GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       -
         name: Helper for custom repo name
         id: reponame
@@ -35,7 +35,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.reponame.outputs.DOCKER_REPO }} # list of Docker images to use as base name for tags
           tags: |
@@ -48,21 +48,21 @@ jobs:
             latest=false
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push master as latest
         if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -75,7 +75,7 @@ jobs:
       -
         name: Build and push branch or test PR
         if: github.ref != 'refs/heads/master'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,5 +1,5 @@
 # Workflow to retrieve test results from 'test' workflow into pull-requests
-# see : https://github.com/EnricoMi/publish-unit-test-result-action/blob/v2.20.0/README.md#support-fork-repositories-and-dependabot-branches
+# see : https://github.com/EnricoMi/publish-unit-test-result-action/blob/v2.24.0/README.md#support-fork-repositories-and-dependabot-branches
 
 name: Test Results
 
@@ -44,7 +44,7 @@ jobs:
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6 #v2.20.0
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 #v2.24.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
           cache: 'pip' # caching pip dependencies


### PR DESCRIPTION
Follow-up to #163: bump the other actions used by the workflows to their latest major versions, several of which still run on the deprecated Node.js 20 runtime.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v7 |
| `docker/metadata-action` | v5 | v6 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `EnricoMi/publish-unit-test-result-action` | v2.20.0 | v2.24.0 (SHA-pinned, per existing convention) |

No intervening breaking change affects this repository's usage:
- `checkout` v7 only restricts fork checkouts on `pull_request_target`/`workflow_run` events; the workflows here check out on `push`, `pull_request`, `schedule` and `workflow_dispatch` only (test-results.yml does no checkout).
- `setup-python` v7 removed the `pip-install` input, which is not used here; `python-version` + `cache: pip` are unchanged.
- The `docker/*` major bumps are runtime (Node.js) updates with no input changes for this usage.
- `publish-unit-test-result-action` v2.24.0 is a minor update within the same major.