### PR TITLE
Install perl so qshape keeps working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,19 @@ LABEL org.opencontainers.image.authors="Mattias Wadman <mattias.wadman@gmail.com
 
 # postsrsd is optional and only installed where Debian builds it: it is missing
 # for armhf in trixie, which is the linux/arm/v7 image.
+# perl is spelled out for qshape, which ships in the postfix package but is a
+# perl script needing File::Find, and which postfix names in no dependency of
+# its own. It is in the image today only because opendkim-tools depends on
+# perl:any, which perl-base cannot satisfy -- none of opendkim's own scripts
+# needs more than perl-base, so that dependency could correctly be narrowed and
+# take qshape down with it on a routine base bump. Naming it here costs nothing
+# now and keeps that from happening.
 RUN \
   apt-get update && \
   apt-get -y --no-install-recommends install \
     procps \
     postfix \
+    perl \
     libsasl2-modules \
     libpam-pwdfile \
     sasl2-bin \

--- a/README.md
+++ b/README.md
@@ -509,6 +509,30 @@ help either: whatever `user:` says, the container hands the DKIM keys to
 those daemons require. Mount the directories and let the container set them
 up; on the host they will show the uids those daemons have inside it.
 
+### Mail is piling up and I want to know what the queue is doing.
+
+Two tools, answering different questions. `qshape` says *which destination owns
+the queue, and since when*: destinations down the side, message age in minutes
+across the top, doubling each column.
+
+```
+docker exec <container> qshape          # incoming and active
+docker exec <container> qshape deferred # what has already failed once
+```
+
+Weight in the young columns on the left is a problem happening now; everything
+in `1280+` is old mail nobody is retrying hard. That ranking is worth most when
+mail leaves by `transport_maps` to several places -- with a single
+`POSTFIX_relayhost` every message shares one next hop, so the domain axis
+describes your senders rather than the fault.
+
+`postqueue -j` says *why*, which `qshape` never sees: one JSON object per queue
+file, carrying `delay_reason` and `bounce_reason` per recipient.
+
+```
+docker exec <container> postqueue -j | jq -r '.recipients[].delay_reason' | sort | uniq -c
+```
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- TESTING -->

--- a/tests/test_qshape.py
+++ b/tests/test_qshape.py
@@ -1,0 +1,17 @@
+"""qshape is the queue-inspection tool the postfix package ships.
+
+It is a perl script needing File::Find, and the postfix package names perl in
+no dependency of its own, so nothing in it guarantees the tool can run. It runs
+here only because opendkim-tools pulls perl in; the Dockerfile names perl
+explicitly so that stays true whatever opendkim does, and this is the test that
+would notice if it stopped being.
+"""
+
+from tests.helpers import container_exec
+
+
+def test_qshape_reports_on_the_queues(postfix):
+    output = container_exec(postfix, ["qshape"])
+
+    # The header row of an empty deferred queue summary.
+    assert "TOTAL" in output


### PR DESCRIPTION
`qshape` ships in the postfix package as `/usr/sbin/qshape`, with a man page, and is a perl script needing `File::Find`. The postfix package names perl in none of its dependency fields, so nothing in it guarantees the interpreter its own tool needs.

It is in the image today only by accident: `opendkim-tools` depends on `perl:any`, which only a `Multi-Arch: allowed` package satisfies — `perl` does, `perl-base` does not and does not provide it either. So `perl` and `perl-modules` land here whether anyone asked or not, and `--no-install-recommends` has nothing to do with it.

That dependency is wider than opendkim needs: its own scripts use nothing outside `perl-base`. Narrowing it would be an ordinary packaging fix, and it would take `qshape` down on a routine base bump for a reason nobody would connect to opendkim. Naming `perl` here adds no package and no bytes today — measured, the image is 68 077 553 B without it and 68 077 892 B with it — and keeps that from happening.

The README gains the queue entry it never had: it named no queue command at all, neither `qshape` nor `postqueue`, so the tool was undiscoverable even while it worked.

`tests/test_qshape.py` turns the accident into a contract. It passes on master as well: this is insurance against a regression, not a live bugfix. #91 reported the failure in 2023 against a buster-based image and no longer reproduces; closing it separately.

---
_Generated by [Claude Code](https://claude.ai/code)_ and reviewed by @tigerblue77

Claude-Session: https://claude.ai/code/session_01U6rtzDXGbLHYB7u8wjzVri