### PR TITLE
Secure the directories holding the DKIM keys, not just the keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,11 +487,21 @@ on-failure` brings it back.
 
 ### I see `key data is not secure: /etc/opendkim/keys can be read or written by other users` error messages.
 
-Some Docker distributions like Docker for Windows and RancherOS seems to handle
-volume permission in way that does not work with OpenDKIM default behavior of
-ensuring safe permissions on private keys.
+OpenDKIM checks the whole path down to a private key, not just the key file,
+and refuses to sign with a key it could reach through a directory other users
+can write. It names that directory in the error, which is why the message can
+point at `/etc/opendkim/keys` while the key itself has perfectly good
+permissions.
 
-A workaround is to disable the check using a `OPENDKIM_RequireSafeKeys=no` environment variable.
+Some Docker distributions like Docker for Windows and RancherOS seems to handle
+volume permission in way that does not work with that behavior. The image now
+gives `/etc/opendkim/keys` and each domain directory below it to `opendkim`
+with mode `700` every time it starts, so a volume mounted with a loose mode is
+corrected rather than inherited, and this error should no longer happen.
+
+If it still does, the volume driver is not honouring those changes. A
+workaround is to disable the check using a `OPENDKIM_RequireSafeKeys=no`
+environment variable, at the cost of the protection it provides.
 
 ### I set `user:` in my compose file and the container fails with `/bin/bash: /root/run: Permission denied`.
 

--- a/run
+++ b/run
@@ -33,6 +33,16 @@ dkimConfig()
     rm -f /etc/opendkim/KeyTable
     rm -f /etc/opendkim/SigningTable
 
+    # opendkim walks the whole path down to a key and refuses one that any
+    # other user could read or write, naming the directory it stopped at
+    # rather than the key. /etc/opendkim/keys is where a volume gets mounted,
+    # so its mode is whatever the volume driver left behind and not something
+    # the image ever set: secure it here, along with the per-domain
+    # directories below, or opendkim declines to sign with a key whose own
+    # permissions are perfectly fine.
+    chown opendkim:opendkim /etc/opendkim/keys
+    chmod a=,u=rwx /etc/opendkim/keys
+
     echo "DNS records:"
     for d in $OPENDKIM_DOMAINS ; do
       domain=$(echo "$d"| cut -f1 -d '=')
@@ -52,6 +62,7 @@ dkimConfig()
 
       # Ensure strict permissions required by opendkim
       chown opendkim:opendkim "$domainDir" "$privateFile"
+      chmod a=,u=rwx "$domainDir"
       chmod a=,u=rw "$privateFile"
 
       echo "$selector._domainkey.$domain $domain:$selector:$privateFile" >> /etc/opendkim/KeyTable

--- a/tests/test_dkim.py
+++ b/tests/test_dkim.py
@@ -56,6 +56,51 @@ def test_the_private_key_is_only_readable_by_opendkim(postfix_factory):
     assert container_exec(relay, f"stat -c %U:%G:%a {KEY_PATH}").strip() == 'opendkim:opendkim:600'
 
 
+def test_the_directories_holding_the_keys_are_secured_too(postfix_factory):
+    """Regression test for issue #92.
+
+    opendkim walks the whole path down to a key and refuses one it could reach
+    through a directory other users can write, naming that directory rather
+    than the key. The key file's own mode being right is not enough, so a
+    correct key was refused and the only answer the README had was to turn the
+    check off with OPENDKIM_RequireSafeKeys=no.
+    """
+    relay = postfix_factory(env={'OPENDKIM_DOMAINS': 'example.com=sel1'})
+
+    for path in ['/etc/opendkim/keys', '/etc/opendkim/keys/example.com']:
+        assert container_exec(relay, ["stat", "-c", "%U:%G:%a", path]).strip() == \
+            'opendkim:opendkim:700'
+
+
+def test_a_key_volume_left_open_by_its_driver_is_corrected(docker_volume, postfix_factory,
+                                                           mailpit):
+    """The mode of /etc/opendkim/keys is whatever mounting left behind.
+
+    The README blames this on volume handling in Docker for Windows and
+    RancherOS. Nothing in the test suite can mount such a volume, but the fix
+    is that the image stops trusting the mode it is given and sets it on every
+    start, which a volume made writable by hand exercises just as well.
+    """
+    env = {'OPENDKIM_DOMAINS': 'example.com=sel1'}
+    relay = postfix_factory(env=env, volumes={docker_volume: '/etc/opendkim/keys'})
+
+    container_exec(relay, ["chmod", "-R", "a=rwx", "/etc/opendkim/keys"])
+
+    restart(relay)
+
+    assert container_exec(relay, ["stat", "-c", "%a", "/etc/opendkim/keys"]).strip() == '700'
+    assert container_exec(relay, ["stat", "-c", "%a", KEY_PATH]).strip() == '600'
+
+    # And the point of all of it: opendkim signs instead of logging that the
+    # key data is not secure.
+    send(relay, sender='sender@example.com', subject='signed despite the volume mode',
+         body='signed body')
+
+    raw = mailpit.raw(mailpit.wait_for_message('signed despite the volume mode')['ID'])
+
+    assert verifies(raw, dkim_dns_record(relay, 'example.com', 'sel1'))
+
+
 def test_keys_are_reused_after_a_restart(postfix_factory, mailpit):
     """Restarting must not hand out a new key, the published DNS record
     would stop matching and every signed mail would fail validation."""


### PR DESCRIPTION
opendkim walks the whole path down to a private key and refuses to sign with one it could reach through a directory other users can write. It names that directory in the error rather than the key, which is why the message reported in #92 could point at a key whose own mode was already 600 opendkim:opendkim, and why the README's own example of the error names /etc/opendkim/keys.

The script set the mode of the key file but never of the directories holding it. /etc/opendkim/keys is a volume mount point, so its mode is whatever the volume driver left behind and the image never touched it. Both it and the per-domain directories are now given to opendkim with mode 700 on every start, the same way the key file already was, so a loose mode is corrected instead of inherited.

This is what the README documented as a known issue with no answer other than disabling the check with OPENDKIM_RequireSafeKeys=no.

Closes #92

Claude-Session: https://claude.ai/code/session_01U6rtzDXGbLHYB7u8wjzVri