### PR TITLE
Give CI jobs distinct names so required checks are unambiguous

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   docker:
+    name: "Build Image"
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         name: Event File
         path: ${{ github.event_path }}
   docker:
+    name: "Pytest"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Both `ci.yml` and `test.yml` had a job keyed `docker`, so both reported a check run named `docker`. Since required status checks match on the check run name, there was no way to require one without the other.

```
ci.yml    docker -> Build Image
test.yml  docker -> Pytest
```

The four check names are now distinct and say what they do: **`Build Image`**, **`Pytest`**, **`Event File`**, **`Test Results`**. Only two `name:` lines are added; no job is referenced by key anywhere (there is no `needs:`), so nothing else changes.

### After merging, update the master ruleset

Required checks are stored by name, so the old names stop matching once this lands. Suggested order to avoid locking `master`:

1. **Before merging** — remove the phantom `ci` entry from the required checks (it is never reported and currently blocks all merges), and remove `docker` if it was added.
2. Merge this pull request.
3. **After merging** — add the new names as required: `Build Image`, `Pytest`, `Test Results`.

Step 1 is needed regardless of this pull request, since nothing can merge while `ci` is required.

Fixes #172.