### PR TITLE
Say that swarm drops the no-new-privileges line

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,10 @@ with them — being the one worth the trouble on a container that listens on a
 network. Relaying, signing, rewriting, the health check and a graceful stop all
 work with the set above, and a test checks that they do.
 
+Under `docker stack deploy` the `security_opt` line is dropped — swarm prints
+`Ignoring unsupported options: security_opt` and the container starts without
+`no-new-privileges`. The capability set above is passed through unchanged.
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- SPF AND DKIM -->


### PR DESCRIPTION
Fixes #182.

The hardening block tells the reader to set `security_opt: no-new-privileges`, and `docker stack deploy` does not pass it on: it prints `Ignoring unsupported options: security_opt` among the rest of its deploy output, which is easy to scroll past, and the container then starts without it. Nothing else in the README recommends something that a supported way of running the image quietly declines to do.

Measured on a swarm deployment of the built image (Docker 29.3.1), with the documented block copied verbatim into a stack file: the container comes up with `CapDrop [ALL]` and the seven `CapAdd` entries exactly as written, `SecurityOpt` empty, et the health check passing. Relaying, DKIM signing and SRS rewriting all work there, and the task exits 0 when rescheduled, so the sentence says the capabilities are unaffected rather than leaving the reader to guess how much of the block survived.

Three lines of prose in the section that makes the recommendation. Nothing outside `README.md` is touched.

---
_Generated by [Claude Code](https://claude.ai/code)_ and reviewed by @tigerblue77