### PR TITLE
Say that the SASL configuration can be mounted

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,30 @@ environment:
   - POSTFIX_smtpd_relay_restrictions=permit_sasl_authenticated,reject
 ```
 
+#### Bringing your own SASL configuration
+
+The example above authenticates against a passwd file because that is what the
+image sets up when you give it nothing else. `/etc/postfix/sasl/smtpd.conf` and
+`/etc/pam.d/smtp` are written at start-up **only when they do not already
+exist**, so mounting either one replaces it and leaves the rest of the setup
+alone. That is how the relay is pointed at something other than a passwd file,
+and how the offered mechanisms are narrowed:
+
+```
+volumes:
+  - /your_local_path/smtpd.conf:/etc/postfix/sasl/smtpd.conf
+  - /your_local_path/pam_smtp:/etc/pam.d/smtp
+```
+
+The generated `smtpd.conf` offers `CRAM-MD5 DIGEST-MD5 LOGIN PLAIN`; a mounted
+one saying `mech_list: PLAIN` is what the relay then advertises.
+
+`SASL_Passwds` still has to be set to something non-empty, whatever those files
+contain. It is what switches the whole SASL block on, and `saslauthd` is started
+inside it, so leaving it empty means no authentication daemon at all. Its value
+is only read as a path by the *generated* PAM profile, so once you mount your
+own it no longer has to point at a passwd file.
+
 ### What runs as root, and what to take away
 
 The container starts as root and cannot do otherwise: postfix refuses to run as


### PR DESCRIPTION
Fixes #189

The image writes `/etc/postfix/sasl/smtpd.conf` and `/etc/pam.d/smtp` only when they do not already exist, so mounting either one replaces it. That is what makes authenticating against something other than a passwd file possible, and `tests/test_sasl.py::test_mounted_sasl_configuration_is_not_overwritten` pins it — it mounts both files and checks that the `mech_list` they carry is the one the relay goes on to advertise.

The README said none of it. Its only SASL content was the `pam_pwdfile` recipe, so the one documented way to authenticate a client was the built-in one. The same "mounted means not overwritten" escape hatch is already documented for the two comparable files, `/etc/postsrsd.secret` under `PostSRSd variables` and the rsyslog configuration under `Advanced logging configuration`; SASL was the only place it existed, was tested, and went unmentioned.

### What this adds

A `#### Bringing your own SASL configuration` subsection under `Client authentication`, directly after the recipe it qualifies, covering three things:

- the two files are written only when absent, so mounting either replaces it;
- the generated `smtpd.conf` offers `CRAM-MD5 DIGEST-MD5 LOGIN PLAIN`, and a mounted one saying `mech_list: PLAIN` is what the relay then advertises;
- **the trap**: both files are written from inside the block `SASL_Passwds` guards (`run` line 159) and `saslauthd` is started inside it (line 185), so `SASL_Passwds` must still be non-empty whatever the mounted files contain. Its value is only read as a path by the *generated* PAM profile (line 177), so once that profile is replaced it no longer has to point at a passwd file. Documenting the mount without this would send an LDAP user down a dead end.

### Verification

Every claim was read off `run` lines 159-186 and `tests/test_sasl.py`, not inferred:

| Claim | Source |
| --- | --- |
| `smtpd.conf` written only when absent | `run:161` |
| `pam.d/smtp` written only when absent | `run:175` |
| generated `mech_list` is `CRAM-MD5 DIGEST-MD5 LOGIN PLAIN` | `run:163` |
| a mounted `mech_list` is what gets advertised | `tests/test_sasl.py:101` |
| `SASL_Passwds` gates the whole block | `run:159` |
| `saslauthd` starts inside that block | `run:185` |
| `SASL_Passwds` read as a path only by the generated profile | `run:177`, the only such use besides the guard and `healthcheck:56` |

Documentation only, no behaviour change. `README.md` is the only file touched: +24 lines, nothing removed. The section list, the table of contents et every anchor are unchanged — 11 top-level sections, 11 back-to-top links, no broken anchor. The new heading is a `####`, a sibling of `Example basic client PAM auth`, so like it it is not listed in the table of contents.

No test is added because the behaviour is already covered by the test cited above.

---
_Generated by [Claude Code](https://claude.ai/code)_