### PR TITLE
Say that swarm's routing mesh hides the client address

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,15 @@ environment:
   - POSTFIX_mynetworks=127.0.0.0/8,172.16.0.0/12
 ```
 
+Addresses are not something to rely on under swarm. `docker stack deploy`
+publishes a port through the routing mesh, which source-NATs, so postfix sees
+the ingress network for every client -- `10.0.0.2` where the client really was
+`192.168.1.192`. `mynetworks` then matches nobody, and widening it to cover the
+ingress network would admit everyone who can reach the published port, which is
+the opposite of the point. Publish with `mode: host` to keep the client
+addresses, or authenticate instead: `permit_sasl_authenticated` does not care
+where the client appears to come from.
+
 or by requiring authentication, using the setup described below and refusing
 everyone else:
 


### PR DESCRIPTION
Fixes #192.

The section on securing the relay offers two ways to stop relaying for everyone, and the first is by address. Under swarm that one does not work: `docker stack deploy` publishes a port through the ingress routing mesh, which source-NATs, so postfix sees the ingress network for every client no matter where it connected from.

Measured on a single-node swarm, same client and same command, only the publish mode changed:

| Publish | `postfix/smtpd: connect from` |
| --- | --- |
| `--publish published=2525,target=25` (the default) | `unknown[10.0.0.2]` |
| `--publish mode=host,published=2525,target=25` | `unknown[192.168.1.192]` |

The failure is loud at first — `mynetworks` matches nobody and nothing relays — but the obvious repair is to widen it to cover `10.0.0.0/24`, and that admits every client that can reach the published port. A rule meant to keep the relay closed ends up holding it open, which earns trois sentences where the advice is given rather than a section of its own.

Nine lines in `README.md`, nothing else touched. No test: the behaviour is docker's, not the image's.

---
_Generated by [Claude Code](https://claude.ai/code)_ and reviewed by @tigerblue77