### PR TITLE
Take the test job from ten minutes to two and a half

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 README.md
 LICENSE
 tests
+pytest.ini

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     # Backstop only. Exceeding a job timeout cancels the job, and a cancelled
     # job does not run the upload below, so the bound that is expected to fire
     # is on the test step instead: it fails, and the results still get reported.
-    timeout-minutes: 40
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -42,10 +42,11 @@ jobs:
         run: pip install -r tests/requirements.txt
       
       - name: Run tests
-        # The suite builds the image and then takes a few minutes; every wait
-        # in it is already bounded, so overrunning this by much means something
-        # is stuck rather than slow.
-        timeout-minutes: 15
+        # The suite builds the image and then runs its files four at a time
+        # (see pytest.ini); it takes about three minutes on this runner. Every
+        # wait in it is bounded, so overrunning this by much means something is
+        # stuck rather than slow.
+        timeout-minutes: 10
         run: pytest --junitxml=junit/test-results.xml
       
       - name: Upload Test Results

--- a/README.md
+++ b/README.md
@@ -643,9 +643,16 @@ pip install -r tests/requirements.txt
 pytest
 # Or a single file
 pytest tests/test_dkim.py
+# Or in a single process, which is easier to follow when working on one test
+pytest -n0
 # Exit python virtual environment
 deactivate
 ```
+
+The suite spends its time waiting on containers rather than on the
+processor, so it runs its files several at a time, which is what
+`pytest.ini` asks for. One file at a time takes about nine minutes and
+leaves the machine mostly idle; four at a time takes about two and a half.
 
 The tests build the image and run it, so what they check is the image
 itself: mail is sent to a container and what comes out of it is read back

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+# The suite is a few hundred containers waiting on each other, not work for
+# the CPU, so it runs several test files at a time. Measured on a 4 vCPU
+# machine of the size CI runs on: 642s serially, 165s at four workers, and no
+# further gain past that -- the longest single file is then the whole run.
+#
+# "loadfile" keeps every test of a file in one worker, which is what the
+# fixtures that pool containers per configuration need to keep paying off,
+# and what keeps a file that shares a relay between its tests from spreading
+# that relay over several workers.
+#
+# "auto" is the number of processors, capped so that a large workstation does
+# not start dozens of relays for no gain. Pass "-n0" to run in one process,
+# which is easier to follow when working on a single test.
+addopts = -n auto --dist loadfile --maxprocesses 4

--- a/tests/fixtures/mailpit.py
+++ b/tests/fixtures/mailpit.py
@@ -1,12 +1,13 @@
 import time
 
+import docker
 import pytest
 import requests
 
 from testcontainers.community.mailpit import MailpitContainer
 
 from tests.conftest import print_log_on_failure
-from tests.helpers import poll_until
+from tests.helpers import once_across_workers, poll_until
 
 IMAGE = "axllent/mailpit:v1.27"
 
@@ -78,8 +79,21 @@ class Mailpit:
 
 
 @pytest.fixture(scope="session")
-def mailpit_container(shared_network):
-    container = MailpitContainer(IMAGE) \
+def mailpit_image(tmp_path_factory):
+    """The mailpit image, pulled once for the whole run.
+
+    Starting a container pulls the image it needs, so without this every
+    worker would pull this one at the same moment as the others.
+    """
+    once_across_workers(tmp_path_factory, "mailpit-image",
+                        lambda: docker.from_env().images.pull(IMAGE))
+
+    return IMAGE
+
+
+@pytest.fixture(scope="session")
+def mailpit_container(shared_network, mailpit_image):
+    container = MailpitContainer(mailpit_image) \
         .with_network(shared_network) \
         .with_network_aliases('mailpit')
 
@@ -98,7 +112,7 @@ def mailpit(mailpit_container):
 
 
 @pytest.fixture
-def mailpit_factory(shared_network, request):
+def mailpit_factory(shared_network, mailpit_image, request):
     """Start extra relay targets, for tests that need their own.
 
         upstream = mailpit_factory('upstream', users=[MailpitUser('user', 'pass')])
@@ -106,7 +120,7 @@ def mailpit_factory(shared_network, request):
     started = []
 
     def start(alias, users=None):
-        container = MailpitContainer(IMAGE, users=users) \
+        container = MailpitContainer(mailpit_image, users=users) \
             .with_network(shared_network) \
             .with_network_aliases(alias)
 

--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -8,22 +8,24 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.core.image import DockerImage
 
 from tests.conftest import print_log_on_failure
-from tests.helpers import poll_until, wait_for_smtp
+from tests.helpers import once_across_workers, poll_until, wait_for_smtp
 
 ROOT_PATH = os.path.dirname(__file__) + '/../../'
+
+IMAGE_TAG = "postfix-relay:test"
 
 # Containers sharing a network need distinct aliases.
 _alias_numbers = itertools.count(1)
 
 
 @pytest.fixture(scope="session")
-def postfix_image():
-    """The image under test, built once for the whole session."""
-    image = DockerImage(path=ROOT_PATH, tag="postfix-relay:test")
+def postfix_image(tmp_path_factory):
+    """The image under test, built once for the whole run."""
+    once_across_workers(
+        tmp_path_factory, "postfix-image",
+        lambda: DockerImage(path=ROOT_PATH, tag=IMAGE_TAG).build())
 
-    image.build()
-
-    return str(image)
+    return IMAGE_TAG
 
 
 def _start(image, network, env=None, files=None, volumes=None, ports=(25,), alias=None,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+import os
 import re
 import smtplib
 import time
@@ -22,6 +23,43 @@ def poll_until(predicate, timeout=DEFAULT_TIMEOUT, description="condition"):
         if time.monotonic() >= deadline:
             raise AssertionError(f"timed out after {timeout}s waiting for {description}")
         time.sleep(0.2)
+
+
+def once_across_workers(tmp_path_factory, name, produce, timeout=600):
+    """Call "produce" once for the whole run, however many workers there are.
+
+    pytest-xdist runs every worker in a process of its own, so a session
+    scoped fixture is set up once per worker rather than once per run. That
+    is what keeps the workers independent and is what one wants for the
+    containers, but not for getting the images they run: the same build
+    would be done several times over, and several pulls of the same base
+    image at the same moment are answered by the registry with a 429 rather
+    than with the image.
+
+    The first worker to create the lock does the work and leaves a marker
+    behind, the others wait for that marker. Without xdist there is nothing
+    to coordinate and "produce" is simply called.
+    """
+    if os.environ.get('PYTEST_XDIST_WORKER') is None:
+        produce()
+        return
+
+    # getbasetemp() is per worker, its parent is shared by all of them.
+    shared = tmp_path_factory.getbasetemp().parent
+    lock = shared / f"{name}.lock"
+    done = shared / f"{name}.done"
+
+    try:
+        os.close(os.open(lock, os.O_CREAT | os.O_EXCL))
+    except FileExistsError:
+        poll_until(done.is_file, timeout=timeout,
+                   description=f"{name} to be made ready by another worker")
+        return
+
+    produce()
+    # Written only once the work is finished, so that a worker seeing it can
+    # rely on the image being there.
+    done.touch()
 
 
 def wait_for_smtp(container, port=25, timeout=DEFAULT_TIMEOUT):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,8 +29,20 @@ def wait_for_smtp(container, port=25, timeout=DEFAULT_TIMEOUT):
 
     A log line only tells that the start-up script got that far, postfix can
     still be a moment away from accepting connections.
+
+    A container that has exited is not waited for: "run" stops the container
+    on a configuration it refuses, so sitting out the timeout on one only
+    delays a failure that is already decided, and reports it as a silent
+    relay rather than as the refusal it is.
     """
+    wrapped = container.get_wrapped_container()
+
     def banner():
+        wrapped.reload()
+        if wrapped.status == 'exited':
+            raise AssertionError(
+                f"the container exited with {wrapped.attrs['State']['ExitCode']} "
+                f"instead of answering on port {port}")
         try:
             smtp = smtplib.SMTP(container.get_container_host_ip(),
                                 container.get_exposed_port(port),
@@ -219,12 +231,19 @@ def _dotted_quad(hex_address):
                     for index in range(6, -2, -2))
 
 
-def exit_code_within(container, seconds=15):
+def exit_code_within(container, seconds=5):
     """The code the container exited with, or None if it is still running.
 
     docker's wait endpoint has no notion of "not yet": asking it to wait
     less than the container takes raises a read timeout, which is the
     answer rather than an error here.
+
+    Five seconds rather than fifteen: "run" waits on the daemon it
+    started in the foreground, so it hears about the death immediately and
+    the container is gone 0.2s later, measured. The wait is what a caller
+    pays when the container does *not* stop, which is the case the callers
+    below are documenting, so keeping it near the time the answer actually
+    takes is most of what those tests cost.
     """
     try:
         return container.get_wrapped_container().wait(timeout=seconds)['StatusCode']

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,11 +2,13 @@
 # its own: CI installs them fresh on every run, and the module the mailpit
 # fixtures import has already been renamed once.
 #
-# These are the packages tests/ imports by name. Their own dependencies are
+# These are the packages tests/ imports by name, together with the pytest
+# plugin pytest.ini asks for. Their own dependencies are
 # not pinned, so a transitive release can still break a run; closing that would
 # need a lock file and something to keep it current.
 dkimpy==1.1.8
 docker==7.2.0
 pytest==9.1.1
+pytest-xdist==3.8.0
 requests==2.34.2
 testcontainers[mailpit]==4.15.0


### PR DESCRIPTION
# Take the test job from ten minutes to two and a half

The `Pytest` job is what a contributor waits for. Measured over the last 25 runs of
`test.yml`: median **585s**, max **692s**, of which the `Run tests` step is 97%
(514-662s). The `Build Image` job is not the problem next to it -- median 38s, max
186s -- so nothing here touches `ci.yml`.

Reproduced on a four processor machine the size of the runner: 642s, which lines up
with CI. Every number below is measured on that machine, and the suite is
215 passed, 1 skipped, 7 xfailed before and after every one of them.

| | wall clock |
| --- | --- |
| before | 642s |
| after the first commit, one process | 521s |
| after both, four workers, cold image and empty build cache | **137s** |

## Stop waiting out timeouts for outcomes that are already decided

Two waits in `tests/helpers.py` watch for something that has already been ruled out,
and they were the two most expensive things in the run.

`wait_for_smtp` polled for a banner for 30s. `run` stops the container on a
configuration it refuses, and a container that is gone will never answer, so the poll
could not succeed and the 30s only delayed a verdict reached in the first second. It
now reads the container state on each poll and fails as soon as it has exited, naming
the exit code. `test_srs.py::test_a_setting_that_needs_a_space_can_be_passed_through`
is that case in the tree today -- the strict xfail for #177 -- and it went from 30.5s
to about two, with a failure that says the container exited 1 instead of that some
relay never answered.

`exit_code_within` waited 15s for a container to stop. Four of the five
parametrisations of
`test_lifecycle.py::test_the_container_stops_when_a_daemon_it_started_exits` are
strict xfails for #176, so they spent the whole bound proving the negative their
marker already states. Measured against the one case that does work, the container is
gone **0.20s** after the daemon is killed. The bound is 5s now, 25x the observed
latency, and those four cost 7.8s each instead of 18.5s.

While measuring this, the root cause of #176 came out cleanly: `run` ends in a bare
`wait`, which only waits on the jobs that shell backgrounded. `opendkim`, `postsrsd`
and the postfix master are started through `service`, so they are not its children at
all, and `saslauthd` is but leaves `rsyslogd` still running. Only `rsyslogd` dying
releases the `wait`. Not fixed here -- this PR changes no image behaviour -- but it is
in the commit message for whoever picks the issue up.

## Run the test files four at a time

The suite is a few hundred containers waiting on each other; hardly any of its time is
the processor's. `pytest.ini` turns on `pytest-xdist` with `--dist loadfile`, which
keeps every test of a file in one worker -- required here rather than preferred,
because `postfix_shared` pools a relay per configuration and splitting a file would
start that relay once per worker. `-n auto` is capped at four because more buys
nothing: 165s at four workers, 162s at six, 169s at eight. The longest single file is
the run by then.

Getting the images has to happen once rather than once per worker. Each worker is a
process with its own session fixtures, so all four built the image and pulled mailpit
simultaneously; with a cold cache that is four concurrent pulls of the same base
image, which the registry answers with 429. That is not a worry, it is what happened
-- 141 errors, all of them `failed to resolve reference
docker.io/library/debian:trixie-20260824-slim ... 429 Too Many Requests`.
`once_across_workers` puts the first worker to claim a lock in charge and has the rest
wait for the marker it leaves once the work is done. Without xdist there is nothing to
coordinate and it calls through.

## What is deliberately unchanged

No test is removed, no assertion weakened, no test skipped or xfailed to save time.
The same asserts run against the same real containers, and the bounds that remain are
still bounds.

Checked rather than assumed:

- the junit XML that `test-results.yml` publishes: 223 entries, 0 failures, 0 errors;
- the container log `conftest.print_log_on_failure` prints, by deliberately failing
  one test on a shared relay and one on its own relay and reading both logs back out
  of the report under four workers;
- stability, over five full parallel runs, all green;
- `-n0` still works, for anyone following a single test.

The job and step timeouts come down with the run they bound. 10 minutes on the test
step is still ~4x what it takes, and it stays the bound meant to fire first so a stuck
run is reported rather than cancelled.

## Left on the table

The image build is now the serial head of the run: one worker builds while the other
three wait, ~40s of the 137s. Building it once in the workflow with buildx and the GHA
cache would cut most of that, but it needs the fixture to accept a pre-built tag,
which is a way to test a stale image, and a GHA cache restore could not be measured
from here. Not worth guessing at, so it is not in this PR.

---
_Generated by [Claude Code](https://claude.ai/code)_