### PR TITLE
Fix the four defects the test suite pinned

### DIFF
--- a/run
+++ b/run
@@ -235,9 +235,6 @@ mech_list: CRAM-MD5 DIGEST-MD5 LOGIN PLAIN
 EOF
   fi
   
-  # Updating saslauthd config to work with chroot
-  dpkg-statoverride --add root sasl 710 /var/spool/postfix/var/run/saslauthd
-  
   # Giving postfix permission to use saslauthd
   adduser postfix sasl
   
@@ -251,7 +248,20 @@ password        required        pam_deny.so
 EOF
   fi
   
-  mkdir -p /var/spool/postfix/var/run/saslauthd
+  # saslauthd makes its mux world writable itself, so the directory holding it
+  # is the access control: root:sasl 710 lets the sasl group in and nobody
+  # else. Postfix drops privileges with initgroups(), so a chrooted smtpd
+  # running as postfix carries the group added just above and can traverse the
+  # directory to reach the socket.
+  #
+  # Set here rather than through dpkg-statoverride, which only records what a
+  # future dpkg unpack should apply -- nothing a container ever runs -- so the
+  # mode never reached the directory at all and re-adding the override was an
+  # error on every restart (issue #179). This has to stay below the
+  # "chown -R postfix:postfix /var/spool/postfix" above, which would take the
+  # directory back.
+  install -d -o root -g sasl -m 710 /var/spool/postfix/var/run/saslauthd
+
   saslauthd -c -r -a pam -m /var/spool/postfix/var/run/saslauthd &
 fi
 

--- a/run
+++ b/run
@@ -118,14 +118,23 @@ srsConfig()
     fi
     chmod a=,u=rw /etc/postsrsd.secret
 
-    # POSTSRSD_var env -> put "var=value" line in /etc/default/postsrsd.
+    # POSTSRSD_var env -> put "var='value'" line in /etc/default/postsrsd.
     # The file is sourced by the init script, so appending overrides the
     # packaged defaults. The block is regenerated to stay idempotent when a
     # container is restarted.
+    #
+    # The value is single quoted because that init script is /bin/sh with
+    # "set -e": unquoted, a value with a space in it is read as an assignment
+    # followed by a command, and the command not being found takes the init
+    # script down with it (issue #177). Embedded single quotes are closed,
+    # escaped and reopened, which is what the replacement below does. Only the
+    # assignment is quoted: the init script still splits the value into words
+    # when it builds the daemon arguments, so SRS_EXTRA_OPTIONS='-A -t60'
+    # still reaches postsrsd as two options.
     sed -i "/$srsMarker/,\$d" /etc/default/postsrsd
     echo "$srsMarker" >> /etc/default/postsrsd
     for e in ${!POSTSRSD_*} ; do
-      echo "${e:9}=${!e}" >> /etc/default/postsrsd
+      printf "%s='%s'\n" "${e:9}" "${!e//\'/\'\\\'\'}" >> /etc/default/postsrsd
     done
 
     # Point postfix at postsrsd, unless the user configured the maps

--- a/run
+++ b/run
@@ -154,6 +154,15 @@ rm -f \
   /run/rsyslogd.pid \
   /var/spool/postfix/pid/master.pid
 
+# A queue mounted from a host directory hides /var/spool/postfix/dev, which
+# ships in the image, empty, and is where rsyslog opens the log socket the
+# chrooted postfix daemons write to. Nothing else recreates it: it has no entry
+# in postfix-files, so "postfix check" does not, and Debian's chroot resync
+# only fills etc/, lib/ and usr/lib/sasl2. Without it rsyslogd reports it
+# cannot create the socket and everything that connects to syslog after
+# chrooting is logged nowhere (issue #180).
+mkdir -p /var/spool/postfix/dev
+
 secretsFromFiles
 
 # POSTMASTER_ADDRESS env -> route postfix's own notifications (notify_classes)

--- a/run
+++ b/run
@@ -1,20 +1,35 @@
 #!/bin/bash
 
-# "service ... start" returns as soon as start-stop-daemon has forked, so a
-# daemon that dies on its configuration does so after a successful start. Wait
-# for it to be there, rather than relaying mail without the signing or the
-# rewriting the container was asked for.
-startService()
-{
-    local name="$1" process="$2" try
+# Every daemon this configuration needs, filled in as each one is started and
+# watched by the supervision loop at the end. Kept here rather than derived
+# from the environment a second time: what was started is what has to stay up.
+supervised=""
 
-    service "$name" start
+# "service ... start" returns as soon as start-stop-daemon has forked and
+# saslauthd daemonises itself, so a daemon that dies on its configuration does
+# so after a successful start. Wait for it to be there, rather than relaying
+# mail without the signing or the rewriting the container was asked for.
+awaitProcess()
+{
+    local process="$1" try
+
     for try in 1 2 3 4 5 ; do
       if pgrep -x "$process" > /dev/null ; then
-        return
+        supervised="$supervised $process"
+        return 0
       fi
       sleep 0.2
     done
+
+    return 1
+}
+
+startService()
+{
+    local name="$1" process="$2"
+
+    service "$name" start
+    awaitProcess "$process" && return
 
     echo "$name did not start, refusing to relay without it." >&2
     exit 1
@@ -219,7 +234,24 @@ for e in ${!OPENDKIM_*} ; do
   echo "${e:9} ${!e}" >> /etc/opendkim.conf
 done
 
-trap "stopping=1; service postfix stop; service opendkim stop; service postsrsd stop; pkill -TERM rsyslogd; pkill -TERM saslauthd" SIGTERM SIGINT
+# Stop everything this script started, on either way out: the container being
+# stopped, or this script giving up on a daemon that is gone. rsyslogd is
+# signalled last and waited for, so that what the others write on their way out
+# still reaches the container log.
+stopDaemons()
+{
+    [ -n "$stopped" ] && return
+    stopped=1
+
+    service postfix stop
+    service opendkim stop
+    service postsrsd stop
+    pkill -TERM saslauthd
+    pkill -TERM rsyslogd
+    wait "$rsyslogPid" 2> /dev/null
+}
+
+trap 'stopping=1 ; stopDaemons' SIGTERM SIGINT
 if [ ! -z "$OPENDKIM_DOMAINS" ] ; then
   dkimConfig
   startService opendkim opendkim
@@ -272,6 +304,10 @@ EOF
   install -d -o root -g sasl -m 710 /var/spool/postfix/var/run/saslauthd
 
   saslauthd -c -r -a pam -m /var/spool/postfix/var/run/saslauthd &
+  awaitProcess saslauthd || {
+    echo "saslauthd did not start, refusing to relay without it." >&2
+    exit 1
+  }
 fi
 
 startService postfix master
@@ -313,14 +349,41 @@ EOF
 fi
 
 rsyslogd -n &
-wait
+rsyslogPid=$!
+supervised="$supervised rsyslogd"
 
-# Reaching this without having been signalled means a daemon started here gave
-# up on its own. Exiting 0 would look like a clean stop and leave an
-# on-failure restart policy with nothing to act on.
-if [ -z "$stopping" ] ; then
-  echo "A daemon exited on its own, stopping the relay." >&2
-  exit 1
-fi
+# rsyslogd is the only one of them that is a child of this script, so the bare
+# "wait" this replaces was watching one daemon out of five and the container
+# went on relaying when any of the other four died (issue #176). Polling
+# "pgrep -x", the way the health check does, watches all of them and needs
+# nothing beyond reading /proc -- signalling a daemon that dropped to its own
+# user would need a capability the README asks deployments to drop.
+while [ -z "$stopping" ] ; do
+  # The sleep runs in the background and is waited for: "wait" is interrupted
+  # by a trapped signal, while a foreground "sleep" would postpone the stop by
+  # a whole interval. "-n" returns on whichever finishes first, so rsyslogd --
+  # the one daemon that is still a job of this shell -- is noticed the moment
+  # it dies rather than at the end of the interval.
+  sleep 2 &
+  wait -n
+  [ -n "$stopping" ] && break
+
+  for daemon in $supervised ; do
+    pgrep -x "$daemon" > /dev/null && continue
+
+    # A daemon takes a moment to actually go away, and a relay that is fine is
+    # not worth stopping over a single missed reading.
+    sleep 1 &
+    wait $!
+    [ -n "$stopping" ] && break 2
+    pgrep -x "$daemon" > /dev/null && continue
+
+    # Exiting 0 would look like a clean stop and leave an on-failure restart
+    # policy with nothing to act on.
+    echo "A daemon exited on its own, stopping the relay: $daemon is gone." >&2
+    stopDaemons
+    exit 1
+  done
+done
 
 exit 0

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -234,9 +234,6 @@ def test_the_container_stops_when_a_daemon_it_started_exits(daemon, env, postfix
     assert exit_code_within(relay) == 1
 
 
-@pytest.mark.xfail(reason="see issue #180: nothing recreates the chroot's /dev "
-                          "when the queue is mounted from an empty directory",
-                   strict=True)
 def test_the_chroot_still_works_when_the_queue_is_mounted_from_the_host(
         tmp_path, postfix_factory):
     """The README's own volume example is a host directory, which is empty.

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -198,8 +198,9 @@ def test_an_interrupt_stops_the_container_cleanly(postfix_factory):
     assert wrapped.wait(timeout=30)['StatusCode'] == 0
 
 
-# Every daemon "run" starts, and what turns it on. rsyslogd is the only one
-# it starts in the foreground, and the only one whose death it notices.
+# Every daemon "run" starts, and what turns it on. rsyslogd is the only one it
+# starts in the foreground; the others are supervised by polling, so all five
+# have to take the container down with them.
 SUPERVISED_DAEMONS = [
     ('rsyslogd', {}),
     ('master', {}),
@@ -211,8 +212,7 @@ SUPERVISED_DAEMONS = [
 
 @pytest.mark.parametrize("daemon,env", SUPERVISED_DAEMONS,
                          ids=[daemon for daemon, _ in SUPERVISED_DAEMONS])
-def test_the_container_stops_when_a_daemon_it_started_exits(daemon, env, postfix_factory,
-                                                            request):
+def test_the_container_stops_when_a_daemon_it_started_exits(daemon, env, postfix_factory):
     """The README's promise, for each of the five daemons in turn.
 
     "A daemon that later gives up on its own exits the container non-zero,
@@ -221,17 +221,16 @@ def test_the_container_stops_when_a_daemon_it_started_exits(daemon, env, postfix
     unlogged, or -- when it is the postfix master that is gone -- not at
     all, with nothing but the health check to say so.
     """
-    if daemon != 'rsyslogd':
-        request.node.add_marker(pytest.mark.xfail(
-            reason="see issue #176: only rsyslogd is started in the foreground, "
-                   "so it is the only one \"wait\" is waiting for",
-            strict=True))
-
     relay = postfix_factory(env=env)
 
     relay.exec(f"pkill -x {daemon}")
 
-    assert exit_code_within(relay) == 1
+    # Longer than the default bound: rsyslogd is a job of the start-up script
+    # and its death is seen at once, but the other four are noticed by the
+    # supervision loop, so the wait has to cover a poll interval and the
+    # second reading that confirms it. It costs nothing when the container
+    # does stop, which is the outcome being asserted.
+    assert exit_code_within(relay, seconds=15) == 1
 
 
 def test_the_chroot_still_works_when_the_queue_is_mounted_from_the_host(

--- a/tests/test_sasl.py
+++ b/tests/test_sasl.py
@@ -100,9 +100,9 @@ def test_authentication_still_works_after_a_restart(restartable_authenticated_re
                                                     mailpit):
     """The second start must not leave the relay unable to authenticate anyone.
 
-    Setting SASL up is not idempotent on the face of it: the statoverride is
-    already registered and postfix is already in the sasl group, and neither
-    failing stops the rest of the script.
+    Setting SASL up is not idempotent on the face of it: postfix is already
+    in the sasl group and the socket directory is already there, and neither
+    of those stops the rest of the script.
     """
     restart(restartable_authenticated_relay)
 
@@ -243,9 +243,6 @@ def test_saslauthd_answers_inside_the_postfix_chroot(authenticated_relay):
     assert 'sasl' in container_exec(authenticated_relay, ["id", "postfix"])
 
 
-@pytest.mark.xfail(reason="see issue #179: the statoverride is recorded but never "
-                          "applied, so the directory keeps the mode mkdir gave it",
-                   strict=True)
 def test_the_saslauthd_socket_is_restricted_to_the_sasl_group(authenticated_relay):
     """Anyone who can reach the socket can ask saslauthd to check a password.
 

--- a/tests/test_srs.py
+++ b/tests/test_srs.py
@@ -83,7 +83,7 @@ def test_secret_and_configuration_survive_a_restart(srs_relay, mailpit):
     # The file is sourced, so the last assignment is the one that counts: the
     # packaged SRS_DOMAIN=localdomain has to stay above ours.
     domains = [line for line in defaults.splitlines() if line.startswith('SRS_DOMAIN=')]
-    assert domains[-1] == f'SRS_DOMAIN={SRS_DOMAIN}'
+    assert domains[-1] == f"SRS_DOMAIN='{SRS_DOMAIN}'"
 
     send(srs_relay, sender='sender@example.com', subject='rewritten after restart')
 
@@ -210,22 +210,30 @@ def test_several_domains_can_be_excluded_at_once(postfix_shared, mailpit):
 
 
 def test_every_postsrsd_variable_reaches_the_daemon(postfix_shared):
-    """The generated block is what /etc/default/postsrsd is read for."""
+    """The generated block is what /etc/default/postsrsd is read for.
+
+    Read back the way the init script reads it -- by sourcing the file with
+    /bin/sh -- rather than by matching the text: what has to hold is the
+    value the daemon is started with, not how it was quoted on the way in.
+    """
     relay = postfix_shared(env={
         'POSTSRSD_SRS_DOMAIN': SRS_DOMAIN,
         'POSTSRSD_SRS_HASHLENGTH': '8',
         'POSTSRSD_SRS_HASHMIN': '6',
     })
 
+    sourced = container_exec(relay, [
+        "sh", "-c", ". /etc/default/postsrsd ; "
+                    'printf "%s|%s|%s" "$SRS_DOMAIN" "$SRS_HASHLENGTH" "$SRS_HASHMIN"'])
+
+    assert sourced == f'{SRS_DOMAIN}|8|6'
+    # And the block is the only place they come from, so it is regenerated
+    # rather than appended to a second time.
     generated = container_exec(relay, ["cat", "/etc/default/postsrsd"]).split(
         GENERATED_MARKER)[1]
-
-    assert sorted(generated.split()) == [
-        f'SRS_DOMAIN={SRS_DOMAIN}', 'SRS_HASHLENGTH=8', 'SRS_HASHMIN=6']
+    assert len(generated.split()) == 3
 
 
-@pytest.mark.xfail(reason="see issue #177: the value is written unquoted into a "
-                          "file the init script sources", strict=True)
 def test_a_setting_that_needs_a_space_can_be_passed_through(postfix_factory):
     """postsrsd's own extra options are documented as a list.
 


### PR DESCRIPTION
The four `xfail(strict=True)` markers #181 left behind, each turned back into an ordinary regression test by the commit that fixes what it describes. One commit per issue.

`223 passed in 2m 44s` locally, no xfail left in the suite. `run` is the only non-test file touched.

**#180 — a mounted queue loses the postfix chroot's `/dev`.** `mkdir -p /var/spool/postfix/dev` beside the pid file cleanup. It ships in the image and nothing recreates it: no entry in `postfix-files`, and Debian's chroot resync only refills `etc/`, `lib/` and `usr/lib/sasl2`. A named volume is seeded from the image and keeps it; the bind mount the README documents hides it, and rsyslogd then cannot create the socket the chrooted daemons log to.

**#179 — the saslauthd socket was never restricted.** `dpkg-statoverride --add` only records an override for a future dpkg unpack, and it ran before the directory existed, so `mkdir` left it 0755 with a 0777 mux inside: any uid in the container could ask saslauthd to check a password, and adding postfix to the `sasl` group was decorative. Replaced with one idempotent `install -d -o root -g sasl -m 710`, which also stops the "override already exists" error on every restart.

**#177 — a `POSTSRSD_` value with a space stopped the container.** The value went into `/etc/default/postsrsd` unquoted, and that file is sourced by an init script running `/bin/sh` with `set -e`, so `SRS_EXTRA_OPTIONS='-A -t60'` — two words, as the packaged file itself documents — was read as an assignment followed by a command. Single quoting the assignment fixes it and leaves word splitting where it belongs: the init script still splits the value when it builds the daemon arguments. The test that read the block back now sources it with `/bin/sh` rather than matching the quoting.

**#176 — only rsyslogd exiting stopped the container.** The other four daemons are not children of the script, so the bare `wait` was watching one of five. Each daemon is now recorded as it is started and a poll loop watches that list, using `pgrep -x` like the health check does — signalling a daemon that dropped to its own user would need CAP_KILL, which the capability set the README documents drops. A miss is confirmed a second later before the relay is stopped over it; the sleeps run in the background so a trapped SIGTERM is still acted on at once; and both ways out go through one function that stops the daemons in the same order, rsyslogd last so what the others log on their way out still reaches the container log. saslauthd is waited for at start-up too, like the three that already were.

#178 is not here: it was fixed on master by #155 while this was being written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)