### PR TITLE
Pin the protocols the relay speaks, instead of inheriting them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,12 @@ RUN \
 # Open relay, trust docker links for firewalling.
 # Try to use TLS when sending to other smtp servers.
 # No TLS for connecting clients, trust docker network to be safe
+# IPv4 only, because the packaged default is whatever the build machine had.
 ENV \
   POSTFIX_myhostname=hostname \
   POSTFIX_mydestination=localhost \
   POSTFIX_mynetworks=0.0.0.0/0 \
+  POSTFIX_inet_protocols=ipv4 \
   POSTFIX_smtp_tls_security_level=may \
   POSTFIX_smtpd_tls_security_level=none \
   OPENDKIM_Socket=inet:12301@localhost \

--- a/README.md
+++ b/README.md
@@ -117,9 +117,17 @@ and remote servers should see: it is used for the 220 greeting and HELO, and
 it also affects `Received` headers and the envelope sender of mail postfix
 generates itself.
 
-The image keeps Debian's `inet_protocols = ipv4`, so it neither accepts
+The image ships `POSTFIX_inet_protocols=ipv4`, so it neither accepts
 connections nor delivers mail over IPv6. Set `POSTFIX_inet_protocols=all` if
-your docker network has IPv6, or recipients you send to are IPv6 only.
+your docker network has IPv6, or recipients you send to are IPv6 only. Note
+that the shipped `POSTFIX_mynetworks=0.0.0.0/0` covers no IPv6 address, so
+turning IPv6 on means widening that too, or clients reaching the relay over
+IPv6 are refused with `Relay access denied`.
+
+The value is set here rather than left to the Debian package, which writes it
+when it is installed from the IPv6 support of the machine doing the build: the
+same Dockerfile otherwise produces a dual stack image on one host and an IPv4
+only image on another.
 
 ### Postfix master.cf variables
 

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -110,17 +110,17 @@ def test_no_optional_daemon_is_running(postfix):
         assert not process_running(postfix, daemon), daemon
 
 
-def test_the_relay_answers_over_ipv4(postfix):
-    """Which protocols the relay speaks is decided when the image is built.
+def test_the_relay_speaks_ipv4_only(postfix):
+    """And the same everywhere, whoever built the image.
 
-    Debian's postfix postinst writes inet_protocols into main.cf from the
-    IPv6 support of the machine running the build, and nothing in this
-    repository pins it: an image built on a host without IPv6 is ipv4 only,
-    and the published one is dual stack, which is not what the README says.
-    What holds either way is that the relay answers over IPv4, which is what
-    a docker network uses unless it was created with IPv6 turned on.
+    Debian's postfix postinst writes inet_protocols into main.cf at install
+    time from the IPv6 support of the machine running the build, so the same
+    Dockerfile used to produce a dual stack image on a runner and an IPv4
+    only one elsewhere. The Dockerfile pins it, which is what makes the
+    README's "set POSTFIX_inet_protocols=all if your docker network has
+    IPv6" a choice rather than a coin toss.
     """
-    assert postconf(postfix, 'inet_protocols') in ('ipv4', 'all')
+    assert postconf(postfix, 'inet_protocols') == 'ipv4'
     assert 25 in listening_ports(postfix)
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -22,6 +22,9 @@ DEFAULT_ENVIRONMENT = [
     ('POSTFIX_myhostname', 'hostname'),
     ('POSTFIX_mydestination', 'localhost'),
     ('POSTFIX_mynetworks', '0.0.0.0/0'),
+    # Pinned rather than inherited: the packaged value is written at build
+    # time from the IPv6 support of the machine doing the build.
+    ('POSTFIX_inet_protocols', 'ipv4'),
     ('POSTFIX_smtp_tls_security_level', 'may'),
     ('POSTFIX_smtpd_tls_security_level', 'none'),
     # OpenDKIM: everything but the domains, which is what turns signing on.


### PR DESCRIPTION
`inet_protocols` was the one setting nobody here decided. Debian's postfix postinst writes it into `main.cf` at install time from the IPv6 support of the machine doing the build, so the same Dockerfile produced `all` on the runners that publish the image and `ipv4` on a host without IPv6 -- the value the README describes.

The dual stack one is half configured on top of that: postfix listens on `::`, but the shipped `POSTFIX_mynetworks=0.0.0.0/0` covers no IPv6 address, so a client arriving over IPv6 is accepted at the TCP level and then refused with `Relay access denied`. An IPv4 only docker network, which is what docker creates unless asked otherwise, hides all of it.

Pinned to `ipv4` beside the other defaults. That makes a build reproducible and turns the README's "set `POSTFIX_inet_protocols=all` if your docker network has IPv6" into a choice rather than a description of the build machine. The README now also says that turning IPv6 on means widening `mynetworks` with it.

The cost, stated plainly: a deployment that was getting IPv6 by accident from a runner-built image has to set `POSTFIX_inet_protocols=all` to keep it.

`223 passed, 1 skipped in 2m 43s` locally. The test asserts `ipv4` firmly again rather than accepting either value -- but it can only prove the pinning where the packaged value would have differed, so **the CI run is what actually checks this**: the runner builds with IPv6 present, so without the pin its `main.cf` would say `all`.

Closes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)