### PR TITLE
Check every inet service, "maxproc 0" included

### DIFF
--- a/healthcheck
+++ b/healthcheck
@@ -35,9 +35,12 @@ listening()
 running master || fail "postfix master is not running"
 
 # Follow master.cf rather than assuming port 25, so a submission port added
-# with a POSTFIXMASTER_ variable is checked too and a service turned off with
-# maxproc 0 is not.
-for service in $(postconf -M | awk '$2 == "inet" && $7 != "0" { print $1 }') ; do
+# with a POSTFIXMASTER_ variable is checked too. Every inet service is looked
+# at: master.cf has no field that turns one off. "maxproc 0" means no process
+# count limit rather than disabled, and postfix binds the port either way; a
+# service that really is disabled is removed with "postconf -MX" and postconf
+# stops printing it at all.
+for service in $(postconf -M | awk '$2 == "inet" { print $1 }') ; do
   endpoint="${service##*:}"
   port=$(getent services "$endpoint" | awk '{ sub("/.*", "", $2) ; print $2 }')
   listening "${port:-$endpoint}" || fail "postfix is not listening on $service"

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -6,6 +6,9 @@ from testcontainers.core.container import DockerContainer
 
 HEALTHCHECK = "/root/healthcheck"
 SUBMISSION = "submission/inet=submission inet n - y - - smtpd"
+# The same service with its process count limit lifted, which postfix starts
+# and binds exactly as it does the one above.
+MAXPROC_ZERO = SUBMISSION.replace("n - y - -", "n - y - 0")
 
 def start_relay(image, **env):
     container = DockerContainer(image=image)
@@ -194,19 +197,28 @@ def test_a_postfix_that_is_not_running_is_unhealthy(relay_factory):
     assert 'postfix master is not running' in output
 
 
-def test_a_service_turned_off_with_maxproc_zero_is_not_expected_to_listen(relay_factory):
-    """Setting maxproc to 0 is how a service in master.cf is turned off.
+def test_a_service_with_no_process_limit_is_still_expected_to_listen(relay_factory):
+    """"maxproc 0" means no process count limit, not "turned off".
 
-    A check that only looked for "inet" services would report a relay whose
-    submission port was deliberately disabled as broken.
+    Postfix binds the port either way, so skipping those services would have
+    left a submission port that never opened unnoticed. There is no field in
+    master.cf that disables a service: one that really is disabled is removed
+    with "postconf -MX", and postconf -M then does not print it at all.
+
+    Written the way test_configured_but_unopened_port_is_unhealthy is, so
+    that it fails if the exclusion is ever put back: the port is genuinely
+    closed until the reload, which is the state an exclusion would hide.
     """
     relay = relay_factory()
 
-    relay.exec(["postconf", "-M", "-e", "submission/inet=" + SUBMISSION.split('=', 1)[1]
-                .replace('n - y - -', 'n - y - 0')])
+    relay.exec(["postconf", "-M", "-e", MAXPROC_ZERO])
+
+    exit_code, output = run_healthcheck(relay, expected=1)
+    assert exit_code == 1
+    assert 'not listening on submission' in output
+
     relay.exec("postfix reload")
 
-    assert 'submission' in relay.exec(["postconf", "-M"]).output.decode()
     assert run_healthcheck(relay, expected=0)[0] == 0
 
 


### PR DESCRIPTION
The health check followed `master.cf` but skipped services whose `maxproc` column was `0`:

```sh
for service in $(postconf -M | awk '$2 == "inet" && $7 != "0" { print $1 }') ; do
```

on the belief the comment states -- *"a service turned off with maxproc 0 is not"* checked.

## The premise is wrong

`maxproc` is a process count limit, and `0` means **no limit**, not *disabled*. Postfix starts the service and binds the port either way. Verified on the built image:

```
# postconf -M -e "submission/inet=submission inet n - y - 0 smtpd" && postfix reload
# grep 024B /proc/net/tcp
   1: 00000000:024B 00000000:0000 0A ...
```

`0A` is `LISTEN`, so the filter excluded a listener that is expected to be there.

The effect was a blind spot pointing the **opposite** way to the one the comment claimed: a `submission` service with `maxproc 0` whose port never opened -- master not reloaded, or the bind failed -- was reported healthy, while the same service with any other `maxproc` was correctly reported as not listening.

Nor is there anything to keep the filter for. `master.cf` has no field that disables a service: one that really is disabled is removed with `postconf -MX`, and `postconf -M` then does not print it at all, so the excluded case cannot arise.

## The test could not fail

`test_a_service_turned_off_with_maxproc_zero_is_not_expected_to_listen` set `maxproc` to `0` **and reloaded**, which leaves 587 listening. The check therefore passed with the filter present or stripped out -- the test was vacuous, and its name and docstring carried the same wrong premise forward.

It is replaced by one shaped like the neighbouring `test_configured_but_unopened_port_is_unhealthy`: the service is added and *not* reloaded, so the port really is closed, which is precisely the state the exclusion used to hide. Reintroducing the filter fails it.

## Verification

Run against the built image, not reasoned about:

| | result |
|---|---|
| New test, **with** the filter still in `healthcheck` | **fails** -- `assert 0 == 1`, a closed port reported healthy |
| New test, filter removed | passes |
| Whole suite | **222 passed, 1 skipped** in 2m42s |

`README.md` already describes the behaviour this restores -- *"postfix is running and listening on every `inet` service in `master.cf`"* -- so it needs no change.

## Scope

Refs #188, which raised this as *"the `maxproc 0` exclusion is untested"*. That was accurate when filed; a test bearing the name landed 19 minutes later in #181, but it cannot fail. The issue's stated rationale -- that dropping the filter would make a healthy relay permanently unhealthy -- is the reverse of what happens, so this fixes the filter rather than adding the test the issue proposed.

---
_Generated by [Claude Code](https://claude.ai/code)_