### PR TITLE
Fix what the suite drops on failure

### DIFF
--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -29,7 +29,7 @@ def postfix_image(tmp_path_factory):
 
 
 def _start(image, network, env=None, files=None, volumes=None, ports=(25,), alias=None,
-           command=None, wait_ready=True, kwargs=None):
+           command=None, wait_ready=True, kwargs=None, register=None):
     container = DockerContainer(image=image) \
         .with_network(network) \
         .with_network_aliases(alias or f"postfix-{next(_alias_numbers)}") \
@@ -54,6 +54,12 @@ def _start(image, network, env=None, files=None, volumes=None, ports=(25,), alia
         container.with_kwargs(**kwargs)
 
     container.start()
+    # Handed over before the wait rather than after it: a relay that never
+    # comes up makes the wait raise, and a caller that only learns about the
+    # container when _start returns would neither stop it nor have it to show
+    # the log of -- which is the one thing that says why it did not come up.
+    if register is not None:
+        register(container)
 
     if wait_ready:
         wait_for_smtp(container, port=ports[0])
@@ -64,11 +70,15 @@ def _start(image, network, env=None, files=None, volumes=None, ports=(25,), alia
 @pytest.fixture(scope="session")
 def postfix(postfix_image, shared_network):
     """Relay with the image default configuration, shared by all tests."""
-    container = _start(postfix_image, shared_network, alias='postfix')
+    started = []
+    try:
+        container = _start(postfix_image, shared_network, alias='postfix',
+                           register=started.append)
 
-    yield container
-
-    container.stop()
+        yield container
+    finally:
+        for container in started:
+            container.stop()
 
 
 @pytest.fixture
@@ -93,11 +103,9 @@ def postfix_factory(postfix_image, shared_network, request):
 
     def start(env=None, files=None, volumes=None, ports=(25,), alias=None, command=None,
               wait_ready=True, kwargs=None):
-        container = _start(postfix_image, shared_network, env=env, files=files,
-                           volumes=volumes, ports=ports, alias=alias, command=command,
-                           wait_ready=wait_ready, kwargs=kwargs)
-        started.append(container)
-        return container
+        return _start(postfix_image, shared_network, env=env, files=files,
+                      volumes=volumes, ports=ports, alias=alias, command=command,
+                      wait_ready=wait_ready, kwargs=kwargs, register=started.append)
 
     yield start
 
@@ -165,8 +173,8 @@ def postfix_shared(_relay_pool, postfix_image, shared_network, request):
         key = (tuple(sorted((env or {}).items())),
                tuple(sorted((files or {}).items())), tuple(ports))
         if key not in _relay_pool:
-            _relay_pool[key] = _start(postfix_image, shared_network, env=env,
-                                      files=files, ports=ports)
+            _start(postfix_image, shared_network, env=env, files=files, ports=ports,
+                   register=lambda container: _relay_pool.__setitem__(key, container))
         container = _relay_pool[key]
         used.append(container)
         return container

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -269,19 +269,21 @@ def _dotted_quad(hex_address):
                     for index in range(6, -2, -2))
 
 
-def exit_code_within(container, seconds=5):
+def exit_code_within(container, seconds=15):
     """The code the container exited with, or None if it is still running.
 
     docker's wait endpoint has no notion of "not yet": asking it to wait
     less than the container takes raises a read timeout, which is the
     answer rather than an error here.
 
-    Five seconds rather than fifteen: "run" waits on the daemon it
-    started in the foreground, so it hears about the death immediately and
-    the container is gone 0.2s later, measured. The wait is what a caller
-    pays when the container does *not* stop, which is the case the callers
-    below are documenting, so keeping it near the time the answer actually
-    takes is most of what those tests cost.
+    Fifteen seconds because that is what the supervision actually needs.
+    rsyslogd is a job of the start-up script and its death is seen at once,
+    but the other four daemons are noticed by the polling loop, which has to
+    come round and then confirm the reading. Measured on the image as it
+    stands, from the kill to the container being gone: rsyslogd 1.3s,
+    postsrsd and saslauthd 3.1s, the postfix master 3.1s, opendkim 7.1s. The
+    bound is a little over twice the slowest of those, and it costs nothing
+    when the container does stop, which is the outcome its caller asserts.
     """
     try:
         return container.get_wrapped_container().wait(timeout=seconds)['StatusCode']


### PR DESCRIPTION
Two follow-ups to #195, measured against master after #197. No image behaviour changes.

### 1. A relay that never comes up is dropped on the floor

`_start` returns the container only after the readiness wait succeeds, so when that wait raises nobody holds it. Reproduced with and without the fix on the same commit:

| | before | after |
| --- | --- | --- |
| pytest outcome | `1 failed, 1 error` | `1 failed` |
| containers still running after pytest exited | **1** | 0 |
| container-log blocks in the report | **0** | 1 |

The extra error is a 403 from docker at teardown, caused by the leaked container. And `print_log_on_failure` only gets containers the fixture collected, so the relay's log was missing from the report in exactly the case where it is the whole answer.

### 2. The stop bound was measured against a defect #197 has since fixed

`exit_code_within` defaulted to 5s, justified in #195 by "gone 0.2s after the kill". True when only `rsyslogd` was watched. Now, measured kill-to-gone: rsyslogd 1.3s, saslauthd 3.0s, master 3.1s, postsrsd 3.1s, **opendkim 7.1s**. The default was wrong and unused (#197's test passes `seconds=15`). It is 15 now, documented with those numbers.

---
_Generated by [Claude Code](https://claude.ai/code)_