### PR TITLE
Test the images that are published, not just the runner's own

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,9 +11,9 @@
 # "Pytest (arm/v7, emulated)", "Event File" and "Test Results"; "ci" and
 # "test" are workflows and never report a check of their own.
 #
-# "Pytest (arm/v7, emulated)" reports "skipped" on a pull request that is not
-# labelled "test-emulated", which is nearly all of them, so requiring it would
-# gate on a check that did not run rather than on one that passed.
+# "Pytest (arm/v7, emulated)" does not run on a pull request unless it is
+# labelled "test-emulated", which is nearly all of them, so it is not a
+# candidate for the required list whatever github makes of a skipped check.
 
 name: Dependabot auto-merge
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,9 +11,9 @@
 # "Pytest (arm/v7, emulated)", "Event File" and "Test Results"; "ci" and
 # "test" are workflows and never report a check of their own.
 #
-# "Pytest (arm/v7, emulated)" does not run on pull requests unless one is
-# labelled "test-emulated", so requiring it would leave every pull request
-# waiting for a check that never arrives.
+# "Pytest (arm/v7, emulated)" reports "skipped" on a pull request that is not
+# labelled "test-emulated", which is nearly all of them, so requiring it would
+# gate on a check that did not run rather than on one that passed.
 
 name: Dependabot auto-merge
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,8 +7,13 @@
 #   does not wait for CI and merges straight away
 #
 # Required checks are matched by job name, not by workflow name. The names
-# that exist are "Build Image", "Pytest", "Event File" and "Test Results";
-# "ci" and "test" are workflows and never report a check of their own.
+# that exist are "Build Image", "Pytest", "Pytest (arm64)",
+# "Pytest (arm/v7, emulated)", "Event File" and "Test Results"; "ci" and
+# "test" are workflows and never report a check of their own.
+#
+# "Pytest (arm/v7, emulated)" does not run on pull requests unless one is
+# labelled "test-emulated", so requiring it would leave every pull request
+# waiting for a check that never arrives.
 
 name: Dependabot auto-merge
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,10 +87,8 @@ jobs:
         run: pip install -r tests/requirements.txt
 
       - name: Run tests
-        # Named, because all three jobs write a file called test-results.xml
-        # and they are published as one report.
         timeout-minutes: 10
-        run: pytest -o junit_suite_name=arm64 --junitxml=junit/test-results.xml
+        run: pytest --junitxml=junit/test-results.xml
 
       - name: Upload Test Results
         if: (!cancelled())
@@ -173,12 +171,13 @@ jobs:
         timeout-minutes: 25
         env:
           POSTFIX_RELAY_IMAGE: postfix-relay:test-armv7
-        run: pytest -m smoke -o junit_suite_name=arm-v7 --junitxml=junit/test-results.xml
+        run: pytest -m smoke --junitxml=junit/test-results.xml
 
       - name: Upload Test Results
         if: (!cancelled())
         uses: actions/upload-artifact@v7
         with:
-          name: Test Results (arm/v7)
+          # No slash: upload-artifact rejects one in an artifact name.
+          name: Test Results (armv7)
           path: |
             junit/*.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,17 @@ on:
     branches:
       - 'master'
   pull_request:
+  # So the emulated job below can be asked for without pushing anything.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+# The three jobs that run pytest are spelled out rather than written as one
+# matrix, because a matrix appends its values to the job name and the names
+# here are what the required status checks and the Dependabot auto-merge
+# workflow match on. See the comment in dependabot-auto-merge.yml.
 
 jobs:
   event_file:
@@ -54,5 +61,124 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: Test Results
+          path: |
+            junit/*.xml
+
+  arm64:
+    name: "Pytest (arm64)"
+    # The same run as the one above, on one of github's arm64 runners. Nothing
+    # is emulated and the image is built here like anywhere else, so this is
+    # the whole suite against the arm64 image everyone pulls, with none of the
+    # timing an emulated run would put in question. Both that image and the
+    # amd64 one have postsrsd; the one that does not is arm/v7, below.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: pip install -r tests/requirements.txt
+
+      - name: Run tests
+        # Named, because all three jobs write a file called test-results.xml
+        # and they are published as one report.
+        timeout-minutes: 10
+        run: pytest -o junit_suite_name=arm64 --junitxml=junit/test-results.xml
+
+      - name: Upload Test Results
+        if: (!cancelled())
+        uses: actions/upload-artifact@v7
+        with:
+          name: Test Results (arm64)
+          path: |
+            junit/*.xml
+
+  arm_v7:
+    name: "Pytest (arm/v7, emulated)"
+    # There is no arm/v7 runner to be had, so this one runs under QEMU, and it
+    # is also the image that genuinely differs rather than being the same one
+    # recompiled: Debian builds no postsrsd for armhf, so the image ships
+    # without it and "run" refuses to start when SRS is asked for anyway.
+    #
+    # Emulation is slow and its failures are harder to read than real ones, so
+    # this stays off the path a pull request waits on: master, a manual run, or
+    # a pull request labelled "test-emulated" for the changes that want it. The
+    # label is read from the event that started the run, so it takes effect on
+    # the next push to the branch; "labeled" is deliberately not a trigger here,
+    # because Dependabot labels its pull requests as it opens them and the
+    # concurrency group above would have that cancel the run it just started.
+    if: >-
+      github.event_name != 'pull_request'
+      || contains(github.event.pull_request.labels.*.name, 'test-emulated')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          # Pinned, unlike the one in ci.yml: that one only has to build an
+          # image, this one runs it, which is where the emulator's own bugs
+          # show up. Left at the default the emulator would change under us
+          # and a new failure here would not say whether the image changed or
+          # the emulator did.
+          image: tonistiigi/binfmt:qemu-v10.2.3-68
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build the arm/v7 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm/v7
+          # One platform at a time, which is all the runner's image store can
+          # hold: it has no room for a manifest list, so a build naming two
+          # platforms cannot be loaded into it at all.
+          load: true
+          tags: postfix-relay:test-armv7
+          # Read only. ci.yml builds the same three platforms and writes the
+          # cache; there is nothing to be gained from this job writing it too.
+          cache-from: type=gha
+
+      - name: Setup python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: pip install -r tests/requirements.txt
+
+      - name: Run the smoke tests
+        # Not the whole suite: every wait in it is measured against a native
+        # run, and emulation invalidates all of them. What runs is the handful
+        # marked "smoke" (see pytest.ini) -- the container starts, reports
+        # healthy, relays a whole message, and answers for the missing
+        # postsrsd -- which is what this job exists to find out.
+        #
+        # Only the relay is emulated. Mailpit publishes no arm/v7 image and
+        # does not need to: it is a separate container on the shared network
+        # and stays native, so nothing here may set a platform globally.
+        timeout-minutes: 25
+        env:
+          POSTFIX_RELAY_IMAGE: postfix-relay:test-armv7
+        run: pytest -m smoke -o junit_suite_name=arm-v7 --junitxml=junit/test-results.xml
+
+      - name: Upload Test Results
+        if: (!cancelled())
+        uses: actions/upload-artifact@v7
+        with:
+          name: Test Results (arm/v7)
           path: |
             junit/*.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,10 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 # The three jobs that run pytest are spelled out rather than written as one
-# matrix, because a matrix appends its values to the job name and the names
-# here are what the required status checks and the Dependabot auto-merge
-# workflow match on. See the comment in dependabot-auto-merge.yml.
+# matrix. They differ in runner, in what they run and in when they run, so a
+# matrix would carry more exceptions than shared lines, and the job names are
+# what the required status checks and the Dependabot auto-merge workflow match
+# on: worth having in front of you. See the comment in dependabot-auto-merge.yml.
 
 jobs:
   event_file:
@@ -135,14 +136,17 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build the arm/v7 image
+        # Bounded for the same reason the test steps are: overrunning the job
+        # timeout cancels the job, and a cancelled job uploads nothing.
+        timeout-minutes: 20
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/arm/v7
-          # One platform at a time, which is all the runner's image store can
-          # hold: it has no room for a manifest list, so a build naming two
-          # platforms cannot be loaded into it at all.
+          # One platform at a time. The runner's docker still keeps images in
+          # the classic store, which has no way to represent a manifest list,
+          # so a build naming two platforms cannot be loaded into it at all.
           load: true
           tags: postfix-relay:test-armv7
           # Read only. ci.yml builds the same three platforms and writes the
@@ -171,7 +175,13 @@ jobs:
         timeout-minutes: 25
         env:
           POSTFIX_RELAY_IMAGE: postfix-relay:test-armv7
-        run: pytest -m smoke --junitxml=junit/test-results.xml
+          # Docker calls the arm/v7 image "arm". Without this the job would
+          # pass against the runner's own amd64 image and report nothing.
+          POSTFIX_RELAY_ARCH: arm
+        # "-n0" overrides pytest.ini: the four smoke tests are in four files,
+        # so the default would put four emulated relays on the runner at once,
+        # against waits that were all measured on a native one.
+        run: pytest -m smoke -n0 --junitxml=junit/test-results.xml
 
       - name: Upload Test Results
         if: (!cancelled())

--- a/README.md
+++ b/README.md
@@ -677,6 +677,26 @@ from mailpit. `tests/fixtures` has the containers and `tests/helpers.py`
 the few things tests keep doing, like waiting for a mail or reading back a
 postfix setting.
 
+Set `POSTFIX_RELAY_IMAGE` to run against an image that is already built
+instead of building one, which is how the suite is pointed at an image for
+another CPU architecture. Building one needs the emulators registered and a
+builder that can cross-build, which the default one cannot:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install arm
+docker buildx create --use --name cross
+docker buildx build --platform linux/arm/v7 --load -t postfix-relay:test-armv7 .
+POSTFIX_RELAY_IMAGE=postfix-relay:test-armv7 pytest -m smoke
+```
+
+CI runs the whole suite on `amd64` and on `arm64`, both natively. There is no
+`arm/v7` runner, so that image is emulated and only the handful of tests
+marked `smoke` run against it -- it starts, reports healthy, relays a message,
+and has no `postsrsd` -- on `master`, on a manual run, or on a pull request
+labelled `test-emulated` before its next push. Emulation is slow enough that
+the rest is not worth its minutes, and every wait in the suite is measured
+against a native run.
+
 | File | What it covers |
 | --- | --- |
 | `test_image.py` | The published image before anything runs: the defaults from the Dockerfile, the declared volumes, the exposed port, the health check, the programs the README has users run out of it |

--- a/README.md
+++ b/README.md
@@ -678,8 +678,11 @@ the few things tests keep doing, like waiting for a mail or reading back a
 postfix setting.
 
 Set `POSTFIX_RELAY_IMAGE` to run against an image that is already built
-instead of building one, which is how the suite is pointed at an image for
-another CPU architecture. Building one needs the emulators registered and a
+instead of building one. It is taken only for an architecture this machine
+cannot build, which is the whole reason it exists: building from the
+`Dockerfile` is what makes the suite test the tree it is run in, and naming an
+image it could have built is refused rather than quietly testing whatever was
+left in the image store. Building one needs the emulators registered and a
 builder that can cross-build, which the default one cannot:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -683,10 +683,14 @@ another CPU architecture. Building one needs the emulators registered and a
 builder that can cross-build, which the default one cannot:
 
 ```bash
-docker run --privileged --rm tonistiigi/binfmt --install arm
-docker buildx create --use --name cross
-docker buildx build --platform linux/arm/v7 --load -t postfix-relay:test-armv7 .
-POSTFIX_RELAY_IMAGE=postfix-relay:test-armv7 pytest -m smoke
+# The same emulator CI pins, so a failure here means the same thing there
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3-68 --install arm
+# Named rather than "--use", which would make it your default for everything
+docker buildx create --name cross --bootstrap
+docker buildx build --builder cross --platform linux/arm/v7 --load \
+  -t postfix-relay:test-armv7 .
+POSTFIX_RELAY_IMAGE=postfix-relay:test-armv7 POSTFIX_RELAY_ARCH=arm \
+  pytest -m smoke -n0
 ```
 
 CI runs the whole suite on `amd64` and on `arm64`, both natively. There is no

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,11 @@
 # not start dozens of relays for no gain. Pass "-n0" to run in one process,
 # which is easier to follow when working on a single test.
 addopts = -n auto --dist loadfile --maxprocesses 4
+
+# The "smoke" tests are the ones worth running against an image the suite did
+# not build, where the whole run is too slow to be worth it: the container
+# starts, it reports healthy, a whole message goes in one end and comes out
+# the other, and the postsrsd the arm/v7 image does not have is answered for
+# both ways round. That is the emulated arm/v7 job in .github/workflows/test.yml.
+markers =
+    smoke: enough to say a foreign architecture image starts and relays

--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -14,13 +14,18 @@ ROOT_PATH = os.path.dirname(__file__) + '/../../'
 
 IMAGE_TAG = "postfix-relay:test"
 
-# An image built outside the suite, for the runs that cannot build their own.
-# Testing a foreign architecture needs buildx to produce the image and the
-# docker daemon to load it, neither of which the builder behind DockerImage
-# does, so CI builds that one itself and names it here. Unset, which is every
-# run on the machine it is meant for, the suite builds the image as it always
-# has.
+# An image built outside the suite, for the runs that cannot build their own:
+# DockerImage builds through the docker daemon, which cannot cross-build, so a
+# foreign architecture has to be built with buildx and loaded first. Unset,
+# which is every run on the machine it is meant for, the suite builds the image
+# as it always has.
 PREBUILT_IMAGE = os.environ.get('POSTFIX_RELAY_IMAGE')
+
+# What that image has to be, as docker reports it: "arm" for the arm/v7 image,
+# "arm64", "amd64". Without this a job that meant to test another architecture
+# and got the runner's own would pass every test it ran and say nothing, which
+# is the one way an emulated run can be worse than no run at all.
+EXPECTED_ARCHITECTURE = os.environ.get('POSTFIX_RELAY_ARCH')
 
 # Containers sharing a network need distinct aliases.
 _alias_numbers = itertools.count(1)
@@ -34,9 +39,12 @@ def postfix_image(tmp_path_factory):
     one is enough to run the suite against an image the suite did not build.
     """
     if PREBUILT_IMAGE:
-        # Asked for once, here, so that a tag that is not loaded says so
-        # instead of failing every test that tries to start a container.
-        docker.from_env().images.get(PREBUILT_IMAGE)
+        image = docker.from_env().images.get(PREBUILT_IMAGE)
+        architecture = image.attrs['Architecture']
+        if EXPECTED_ARCHITECTURE and architecture != EXPECTED_ARCHITECTURE:
+            raise AssertionError(
+                f"{PREBUILT_IMAGE} is {architecture}, not {EXPECTED_ARCHITECTURE}: "
+                "the tests would have passed against the wrong architecture")
         return PREBUILT_IMAGE
 
     once_across_workers(

--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -14,13 +14,31 @@ ROOT_PATH = os.path.dirname(__file__) + '/../../'
 
 IMAGE_TAG = "postfix-relay:test"
 
+# An image built outside the suite, for the runs that cannot build their own.
+# Testing a foreign architecture needs buildx to produce the image and the
+# docker daemon to load it, neither of which the builder behind DockerImage
+# does, so CI builds that one itself and names it here. Unset, which is every
+# run on the machine it is meant for, the suite builds the image as it always
+# has.
+PREBUILT_IMAGE = os.environ.get('POSTFIX_RELAY_IMAGE')
+
 # Containers sharing a network need distinct aliases.
 _alias_numbers = itertools.count(1)
 
 
 @pytest.fixture(scope="session")
 def postfix_image(tmp_path_factory):
-    """The image under test, built once for the whole run."""
+    """The image under test, built once for the whole run.
+
+    Every test reaches the image through here, so pointing this at a prebuilt
+    one is enough to run the suite against an image the suite did not build.
+    """
+    if PREBUILT_IMAGE:
+        # Asked for once, here, so that a tag that is not loaded says so
+        # instead of failing every test that tries to start a container.
+        docker.from_env().images.get(PREBUILT_IMAGE)
+        return PREBUILT_IMAGE
+
     once_across_workers(
         tmp_path_factory, "postfix-image",
         lambda: DockerImage(path=ROOT_PATH, tag=IMAGE_TAG).build())

--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -19,6 +19,11 @@ IMAGE_TAG = "postfix-relay:test"
 # foreign architecture has to be built with buildx and loaded first. Unset,
 # which is every run on the machine it is meant for, the suite builds the image
 # as it always has.
+#
+# Only accepted for an architecture this machine cannot build, which is the
+# whole of the case for having it. Building from the Dockerfile is what makes
+# the suite test the tree it is run in rather than whatever was left in the
+# image store, and that is not worth giving up anywhere it can still be done.
 PREBUILT_IMAGE = os.environ.get('POSTFIX_RELAY_IMAGE')
 
 # What that image has to be, as docker reports it: "arm" for the arm/v7 image,
@@ -39,12 +44,22 @@ def postfix_image(tmp_path_factory):
     one is enough to run the suite against an image the suite did not build.
     """
     if PREBUILT_IMAGE:
-        image = docker.from_env().images.get(PREBUILT_IMAGE)
+        client = docker.from_env()
+        image = client.images.get(PREBUILT_IMAGE)
         architecture = image.attrs['Architecture']
+
+        if architecture == client.version()['Arch']:
+            raise AssertionError(
+                f"POSTFIX_RELAY_IMAGE names a {architecture} image, which this "
+                "machine can build: the suite builds from the Dockerfile so "
+                "that what it tests is what is in the tree. It takes a "
+                "prebuilt image only where the docker builder cannot make one.")
+
         if EXPECTED_ARCHITECTURE and architecture != EXPECTED_ARCHITECTURE:
             raise AssertionError(
                 f"{PREBUILT_IMAGE} is {architecture}, not {EXPECTED_ARCHITECTURE}: "
                 "the tests would have passed against the wrong architecture")
+
         return PREBUILT_IMAGE
 
     once_across_workers(

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -205,17 +205,28 @@ def test_openssl_is_available(image_shell):
     assert output.startswith('OpenSSL')
 
 
+@pytest.mark.smoke
 def test_postsrsd_is_installed_for_this_architecture(image_shell):
     """Debian does not build it for armhf, and "run" says so instead of
     relaying without the rewriting that was asked for. Everywhere else it
-    has to be there."""
+    has to be there.
+
+    Asserted both ways round rather than skipped on armhf, so that the one
+    architecture this is about is also the one it can fail on. The absence is
+    what the conditional install in the Dockerfile, the guard in "run", the
+    note in the README and the skip that used to be here all rest on, and a
+    point release that started shipping the package would leave every one of
+    them saying something untrue with nothing to notice.
+    """
     _, architecture = image_shell("dpkg --print-architecture")
     _, installed = image_shell("command -v postsrsd")
 
     if architecture.strip() == 'armhf':
-        pytest.skip("Debian does not build postsrsd for armhf in trixie")
-
-    assert installed.strip() == '/usr/sbin/postsrsd'
+        assert installed.strip() == '', \
+            "Debian now builds postsrsd for armhf, so the arm/v7 image has " \
+            "SRS after all: the Dockerfile, run and the README say otherwise"
+    else:
+        assert installed.strip() == '/usr/sbin/postsrsd'
 
 
 def test_the_certificate_authorities_are_installed(image_shell):

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -19,6 +19,7 @@ def health(container):
     return wrapped.attrs['State']['Health']['Status']
 
 
+@pytest.mark.smoke
 def test_the_container_reports_healthy(postfix):
     assert poll_until(lambda: health(postfix) == 'healthy', timeout=60,
                       description="the container to report healthy")

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -21,8 +21,19 @@ def health(container):
 
 @pytest.mark.smoke
 def test_the_container_reports_healthy(postfix):
-    assert poll_until(lambda: health(postfix) == 'healthy', timeout=60,
-                      description="the container to report healthy")
+    try:
+        assert poll_until(lambda: health(postfix) == 'healthy', timeout=60,
+                          description="the container to report healthy")
+    except AssertionError:
+        # Docker keeps what every probe printed and exited with, and a timeout
+        # on its own says only that none of them passed. That is the whole
+        # difference between "the check is too slow here" and "a daemon is
+        # down", which is the question an emulated run exists to answer.
+        wrapped = postfix.get_wrapped_container()
+        wrapped.reload()
+        for probe in wrapped.attrs['State']['Health'].get('Log', []):
+            print(f"health probe exited {probe['ExitCode']}: {probe['Output']}")
+        raise
 
 
 def test_relaying_still_works_after_an_unclean_stop(postfix_factory, mailpit):

--- a/tests/test_sendmail.py
+++ b/tests/test_sendmail.py
@@ -4,7 +4,10 @@ from email.message import EmailMessage
 from email.utils import make_msgid
 from email.headerregistry import Address
 
+import pytest
 
+
+@pytest.mark.smoke
 def test_sendmail(mailpit, smtp):
     # Send email to postfix
     msg = EmailMessage()

--- a/tests/test_srs.py
+++ b/tests/test_srs.py
@@ -248,16 +248,21 @@ def test_a_setting_that_needs_a_space_can_be_passed_through(postfix_factory):
     assert process_running(relay, 'postsrsd')
 
 
+@pytest.mark.smoke
 def test_the_container_refuses_to_start_without_postsrsd(postfix_factory):
     """Debian builds no postsrsd for armhf, so the arm/v7 image has none.
 
     Asking for SRS there stops the container instead of relaying without the
-    rewriting that was asked for, which would be a silent SPF failure. CI runs
-    on amd64, where the package exists, so the binary is hidden to reach the
-    branch rather than the architecture being changed.
+    rewriting that was asked for, which would be a silent SPF failure. On the
+    architectures that do have the package, which is where this usually runs,
+    the binary is hidden to reach the branch rather than the architecture
+    being changed; against the arm/v7 image there is nothing to hide and the
+    branch is reached the way a user would reach it.
     """
     relay = postfix_factory(
         env={'POSTSRSD_SRS_DOMAIN': SRS_DOMAIN},
+        # "command -v" finds nothing on armhf, and "rm -f" is untroubled by
+        # the empty name that leaves.
         command=['/bin/bash', '-c',
                  'rm -f "$(command -v postsrsd)" /etc/default/postsrsd /etc/init.d/postsrsd'
                  ' && exec /root/run'],


### PR DESCRIPTION
The image is built and published for amd64, arm/v7 and arm64, and the suite only ever ran against whichever one the runner happened to be, which is amd64. Two of the three were never started by a single test.

That is not academic for arm/v7, which is a different image rather than the same one recompiled: Debian builds no postsrsd for armhf in trixie, so the Dockerfile installs it conditionally and "run" refuses to start when SRS is asked for without it. The whole Depends closure differs by that one package and nothing else, but nothing would notice if that stopped being true.

arm64 needs no emulation at all. Github hosts arm64 runners, free for public repositories, so the suite runs there the way it runs anywhere: it builds the image itself and starts it natively. That is one more run of the same shape and no new way to be flaky, so it gates a pull request like the amd64 run does.

arm/v7 has no runner and has to be emulated, which is slow and fails in ways that read like real failures, so it stays off the path a pull request waits on -- master, a manual run, or a pull request labelled "test-emulated", read off its next push. "labeled" is deliberately not a trigger: Dependabot labels its pull requests as it opens them, and the concurrency group would have that cancel the run it had just started.

Only the handful of tests marked "smoke" run there: the container starts, reports healthy, relays a whole message, and answers for the postsrsd it does not have. Emulating the rest would mean measuring waits that were all measured against a native run. The image's own timings are left alone for the same reason: if a daemon needs longer than "run" allows under QEMU, that is worth seeing rather than worth configuring away.

The suite could not be pointed at an image it had not built, so POSTFIX_RELAY_IMAGE now names one. Every test reaches the image through the postfix_image fixture, so that one place is enough; a foreign architecture needs buildx to produce the image and the daemon to load it, neither of which the builder behind DockerImage does. Only the relay is emulated -- mailpit publishes no arm/v7 image and does not need to, being a separate container on the shared network.

test_postsrsd_is_installed_for_this_architecture asserts both ways round now rather than skipping on armhf. Skipping left it unable to fail on the one architecture it is about, so a point release that started shipping the package would have left the Dockerfile, "run" and the README all saying something untrue with nothing to notice -- which is the case the issue leads with.

The three jobs that run pytest are spelled out rather than written as a matrix: a matrix appends its values to the job name, and the names are what the required status checks and the Dependabot auto-merge workflow match on.

Closes #187.


Claude-Session: https://claude.ai/code/session_015zrA7xtUnRhkFoqCKzgFog