### PR TITLE
Read the health check's verdict without racing the supervisor

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -109,6 +109,37 @@ def send(container, port=25, sender="sender@example.com", recipients=("receiver@
     return subject
 
 
+def healthcheck_after_stopping(container, daemon, stop=None, timeout=10):
+    """Stop a daemon and read what the health check then says, in one exec.
+
+    The supervision loop in "run" stops the container about a second after
+    it notices a daemon is gone, and it notices within a poll interval of
+    the daemon actually exiting -- which is not the same moment as the
+    signal, since opendkim takes about three seconds to shut down. That
+    leaves roughly two seconds between the verdict this asserts and the
+    container going away.
+
+    Polling the check from the outside spends that window on docker round
+    trips, and losing it does not fail on the assertion: the next exec
+    lands on a container that is gone and raises a docker error instead.
+    Killing, waiting and running the check inside the container is one
+    exec, issued while the container is certainly still up, so the whole
+    race is the tail of a single call.
+
+    "timeout" bounds the wait for the daemon to go. Running the check
+    anyway afterwards is deliberate: a daemon that never went reports
+    healthy, which fails on the assertion the caller wrote rather than on
+    a timeout that says nothing about what the check would have said.
+    """
+    return container.exec([
+        "sh", "-c",
+        f'{stop or f"pkill -x {daemon}"} ; '
+        f'for _ in $(seq {timeout * 10}) ; do '
+        f'pgrep -x {daemon} > /dev/null || break ; sleep 0.1 ; '
+        f'done ; '
+        f'/root/healthcheck'])
+
+
 def container_exec(container, command):
     """Run a command in the container and return its output, failing on a non zero exit."""
     result = container.exec(command)

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -4,6 +4,8 @@ import time
 
 from testcontainers.core.container import DockerContainer
 
+from tests.helpers import healthcheck_after_stopping
+
 HEALTHCHECK = "/root/healthcheck"
 SUBMISSION = "submission/inet=submission inet n - y - - smtpd"
 # The same service with its process count limit lifted, which postfix starts
@@ -48,12 +50,10 @@ def test_relay_with_everything_running_is_healthy(signing_relay):
     assert exit_code == 0
 
 def test_stopped_opendkim_is_unhealthy(signing_relay):
-    signing_relay.exec("pkill -x opendkim")
-
-    exit_code, output = run_healthcheck(signing_relay, expected=1)
+    exit_code, output = healthcheck_after_stopping(signing_relay, "opendkim")
 
     assert exit_code == 1
-    assert 'relayed unsigned' in output
+    assert 'relayed unsigned' in output.decode()
 
 def test_relay_stops_when_a_daemon_exits(postfix_image):
     container = start_relay(postfix_image)
@@ -163,12 +163,10 @@ def test_stopped_postsrsd_is_unhealthy(relay_factory):
     SRS was turned on to rewrite."""
     relay = relay_factory(POSTSRSD_SRS_DOMAIN='srs.example.com')
 
-    relay.exec("pkill -x postsrsd")
-
-    exit_code, output = run_healthcheck(relay, expected=1)
+    exit_code, output = healthcheck_after_stopping(relay, "postsrsd")
 
     assert exit_code == 1
-    assert 'envelope senders are not rewritten' in output
+    assert 'envelope senders are not rewritten' in output.decode()
 
 
 def test_stopped_saslauthd_is_unhealthy(relay_factory):
@@ -176,12 +174,10 @@ def test_stopped_saslauthd_is_unhealthy(relay_factory):
     client that tries to authenticate."""
     relay = relay_factory(SASL_Passwds='/etc/postfix/sasl/sasl_passwds')
 
-    relay.exec("pkill -x saslauthd")
-
-    exit_code, output = run_healthcheck(relay, expected=1)
+    exit_code, output = healthcheck_after_stopping(relay, "saslauthd")
 
     assert exit_code == 1
-    assert 'clients cannot authenticate' in output
+    assert 'clients cannot authenticate' in output.decode()
 
 
 def test_a_postfix_that_is_not_running_is_unhealthy(relay_factory):
@@ -189,12 +185,13 @@ def test_a_postfix_that_is_not_running_is_unhealthy(relay_factory):
     no mail is being accepted at all."""
     relay = relay_factory()
 
-    relay.exec("postfix stop")
-
-    exit_code, output = run_healthcheck(relay, expected=1)
+    # Stopped the way an operator would, but the master is supervised like
+    # the rest, so this is the same race as the daemons above.
+    exit_code, output = healthcheck_after_stopping(relay, "master",
+                                                   stop="postfix stop")
 
     assert exit_code == 1
-    assert 'postfix master is not running' in output
+    assert 'postfix master is not running' in output.decode()
 
 
 def test_a_service_with_no_process_limit_is_still_expected_to_listen(relay_factory):

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -10,7 +10,8 @@ import pytest
 
 from testcontainers.community.mailpit import MailpitUser
 
-from tests.helpers import container_exec, container_log, poll_until, send
+from tests.helpers import (container_exec, container_log,
+                           healthcheck_after_stopping, send)
 
 UPSTREAM = '[secrets-upstream]:1025'
 USER, PASSWORD = 'relay', 's3cret'
@@ -26,15 +27,6 @@ def container_stderr(container):
 def healthcheck(container):
     """Run the image health check, which only sees the container environment."""
     return container.exec(["/root/healthcheck"])
-
-
-def wait_for_unhealthy(container, timeout=15):
-    """A killed daemon takes a moment to go away, and docker retries anyway."""
-    def failed():
-        result = healthcheck(container)
-        return result if result.exit_code != 0 else None
-
-    return poll_until(failed, timeout=timeout, description="the health check to fail")
 
 
 @pytest.fixture
@@ -116,9 +108,8 @@ def test_a_domain_list_from_a_file_is_watched_by_the_health_check(postfix_factor
 
     assert healthcheck(relay).exit_code == 0
 
-    relay.exec(["pkill", "-x", "opendkim"])
-
-    assert 'relayed unsigned' in wait_for_unhealthy(relay).output.decode()
+    assert 'relayed unsigned' in \
+        healthcheck_after_stopping(relay, "opendkim").output.decode()
 
 
 def test_an_srs_domain_from_a_file_is_watched_by_the_health_check(postfix_factory):
@@ -127,6 +118,5 @@ def test_an_srs_domain_from_a_file_is_watched_by_the_health_check(postfix_factor
 
     assert healthcheck(relay).exit_code == 0
 
-    relay.exec(["pkill", "-x", "postsrsd"])
-
-    assert 'not rewritten' in wait_for_unhealthy(relay).output.decode()
+    assert 'not rewritten' in \
+        healthcheck_after_stopping(relay, "postsrsd").output.decode()


### PR DESCRIPTION
Closes #204.

Five tests kill a daemon and then ask the health check what it says about it. Both things are true after that kill: the check reports the daemon gone, and `run` stops the container over it. The tests want the first, and they were reading it across the window in which the second happens.

## The window, measured on the built image

`run` polls every two seconds and confirms a second later, counted from when the daemon actually exits -- not from the signal:

| daemon | verdict at | container gone at | margin |
|---|---|---|---|
| `opendkim` | 2.4s | 4.7s | **2.2s** |
| `postsrsd` | 0.1s | 2.9s | 2.8s |
| `saslauthd` | 0.1s | 2.9s | 2.8s |

`opendkim` is the tight one: it takes about three seconds to shut down on `SIGTERM` (`pgrep -x opendkim` still matched at 2.87s).

## What made it a race

The verdict was polled from outside every half second, so up to six docker round trips had to fit inside those 2.2 seconds -- and that is the part that scales with load, on a suite that runs four files at a time. Losing did not fail on the assertion: the next `container.exec` lands on a container that is gone and raises a `docker.errors.APIError`, which says nothing about the health check.

## The change

One helper in `tests/helpers.py`, `healthcheck_after_stopping`, does the kill, the wait and the check in a **single exec**, issued while the container is certainly still up:

```python
container.exec(["sh", "-c",
    f'{stop or f"pkill -x {daemon}"} ; '
    f'for _ in $(seq {timeout * 10}) ; do '
    f'pgrep -x {daemon} > /dev/null || break ; sleep 0.1 ; '
    f'done ; '
    f'/root/healthcheck'])
```

The wall-clock margin is unchanged -- it belongs to `run` -- but the window now holds one call instead of a sequence, and nothing in the critical path scales with load.

Six call sites converted: four in `tests/test_healthcheck.py` (including `test_a_postfix_that_is_not_running_is_unhealthy`, since the master is supervised like the rest and `postfix stop` starts the same clock) et deux dans `tests/test_secrets.py`, whose own `wait_for_unhealthy` polling helper is removed as the last of its users goes.

`test_relay_stops_when_a_daemon_exits` and `tests/test_lifecycle.py`'s parametrised test are untouched: they want the container to stop, which is what they wait for.

## Verification

| | result |
|---|---|
| Whole suite | **223 passed, 1 skipped** in 2m16s |
| Both converted `opendkim` tests, against an image whose health check has no `opendkim` branch | **fail on their own assertion**, not on a docker error |

The negative control matters here: rewriting a test to be less flaky is worth nothing if it also stops failing when the thing it tests is broken.

---
_Generated by [Claude Code](https://claude.ai/code)_