### PR TITLE
Show that the notice recipients are inert until asked for

### DIFF
--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -26,6 +26,7 @@ REPORTING = {
     'POSTMAP_transport': 'nowhere.example smtp:[nothing.invalid]:25',
 }
 UNDELIVERABLE = 'receiver@nowhere.example'
+SENDER = 'sender@example.com'
 
 
 @pytest.fixture
@@ -112,14 +113,40 @@ def test_a_notice_actually_reaches_the_address(postfix_shared, mailpit):
     assert 'Host or domain name not found' in notice['Text']
 
 
+def test_the_recipients_are_inert_at_the_default_notify_classes(postfix_shared,
+                                                                mailpit):
+    """What the README promises for the three classes set anyway.
+
+    "notify_classes keeps its default, and the bounce, 2bounce and delay
+    recipients are only used if you widen it with POSTFIX_notify_classes.
+    They are set anyway so that they are already correct if you do." So a
+    bounce on a relay that did not widen it reaches the sender and nobody
+    else: naming an address must not start sending mail that was not being
+    sent before.
+    """
+    relay = postfix_shared(env={name: value for name, value in REPORTING.items()
+                                if name != 'POSTFIX_notify_classes'})
+
+    send(relay, sender=SENDER, recipients=(UNDELIVERABLE,),
+         subject='not reported to the postmaster')
+
+    bounce = mailpit.wait_for_message('Undelivered Mail Returned to Sender')
+    assert [to['Address'] for to in bounce['To']] == [SENDER]
+
+    # The postmaster copy is written by the same bounce daemon run as the
+    # sender's bounce, so one that was being sent would have arrived too.
+    assert [summary['Subject'] for summary in mailpit.summaries()
+            if 'Postmaster Copy' in summary['Subject']] == []
+
+
 def test_the_sender_still_gets_its_own_bounce(postfix_shared, mailpit):
     """The postmaster copy is a copy: telling the operator must not stop the
     person who sent the message from being told."""
     relay = postfix_shared(env=REPORTING)
 
-    send(relay, sender='sender@example.com', recipients=(UNDELIVERABLE,),
+    send(relay, sender=SENDER, recipients=(UNDELIVERABLE,),
          subject='also bounced to the sender')
 
     bounce = mailpit.wait_for_message('Undelivered Mail Returned to Sender')
 
-    assert [to['Address'] for to in bounce['To']] == ['sender@example.com']
+    assert [to['Address'] for to in bounce['To']] == [SENDER]


### PR DESCRIPTION
Refs #201.

The README says naming a postmaster address costs nothing in extra mail:

> `notify_classes` keeps its default, and the bounce, 2bounce and delay recipients are only used if you widen it with `POSTFIX_notify_classes`. They are set anyway so that they are already correct if you do.

Nothing showed that. `test_a_notice_actually_reaches_the_address` widens `notify_classes` to `bounce` first (`tests/test_postmaster.py:24`), so what is proven end to end is the case the user opts into. The shipped default -- what every deployment that sets `POSTMASTER_ADDRESS` and nothing else actually gets -- had `postconf` read-backs and no more.

A relay that started copying the postmaster on every bounce out of the box would have passed the suite, while being exactly the surprise the README promises it is not.

## The test

The same bounce as the existing tests, on the same configuration minus the `notify_classes` key: the sender gets its `Undelivered Mail Returned to Sender` and nothing else is relayed.

```python
relay = postfix_shared(env={name: value for name, value in REPORTING.items()
                            if name != 'POSTFIX_notify_classes'})
```

Also makes the sender address the two bounce tests share a constant; it is asserted in both, and one of them spelled it out three times.

## Verification

| | result |
|---|---|
| Whole suite | **224 passed, 1 skipped** in 2m15s |
| Same test with `notify_classes` left widened | **fails** -- the postmaster copy arrives |

The negative control is what says the assertion is looking at the right thing rather than at an empty mailbox.

## What is not here

#201 has a second half: a test pinning what an explicitly empty `POSTFIX_<class>_notice_recipient` does. Writing it turned up a defect rather than a coverage gap -- an empty `error_notice_recipient` makes every `smtpd` session die while the health check still reports healthy -- so it is filed as its own issue instead. There is no passing test to write for it until it is decided what should happen, so that half of #201 is not closed by this.

---
_Generated by [Claude Code](https://claude.ai/code)_