### PR TITLE
Say what the suite costs now, not what it cost in August

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ deactivate
 
 The suite spends its time waiting on containers rather than on the
 processor, so it runs its files several at a time, which is what
-`pytest.ini` asks for. One file at a time takes about nine minutes and
+`pytest.ini` asks for. One file at a time takes about eight minutes and
 leaves the machine mostly idle; four at a time takes about two and a half.
 
 The tests build the image and run it, so what they check is the image

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,9 @@
 [pytest]
 # The suite is a few hundred containers waiting on each other, not work for
 # the CPU, so it runs several test files at a time. Measured on a 4 vCPU
-# machine of the size CI runs on: 642s serially, 165s at four workers, and no
-# further gain past that -- the longest single file is then the whole run.
+# machine of the size CI runs on: 476s serially, 140s at four workers, and no
+# further gain past that -- 138s at six and 138s at eight, because the longest
+# single file is the whole run by then.
 #
 # "loadfile" keeps every test of a file in one worker, which is what the
 # fixtures that pool containers per configuration need to keep paying off,


### PR DESCRIPTION
`pytest.ini` and the README carry the measurements that decided how the suite runs, and both were taken before the four defects the suite had pinned were fixed. Four of those fixes changed what the suite does with its time: #176's four cases each waited out a bound for a container that was never going to stop, and #177's case waited out a readiness timeout for a container that had already exited.

Measured again on the same kind of machine, on the suite as it stands:

| | was | is |
| --- | --- | --- |
| one process | 642s | **476s** |
| four workers | 165s | **140s** |

The conclusion those numbers support is unchanged, and was re-checked rather than assumed: 138s at six workers and 138s at eight, so four is still where the gain stops.

Worth recording how nearly that went wrong: the first attempt said the opposite, 189s at four against 136s at six, which would have argued for raising the cap. The four-worker run was simply the one that built the image. Repeating it with the image already built is what showed that up.

Documentation only. No test, fixture or workflow changes.

---
_Generated by [Claude Code](https://claude.ai/code)_