### PR TITLE
Ask postfix for a greeting before handing over

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,14 @@ mail without the signing or rewriting that was configured, and a daemon that
 later gives up on its own exits the container non-zero, so `restart:
 on-failure` brings it back.
 
+Postfix is held to the same rule one step further in: start-up asks it for a
+greeting before handing over, because a running `master` is not yet a relay
+that works. Master binds the port and starts an `smtpd` per connection, so a
+setting `smtpd` rejects when it reads it leaves a container that listens,
+accepts, and kills every session — with a running master and an open socket
+for the health check to find. The container stops instead, and the postfix
+`fatal:` line naming the setting is in the log above.
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- TROUBLESHOOTING -->

--- a/run
+++ b/run
@@ -24,6 +24,51 @@ awaitProcess()
     return 1
 }
 
+# The first smtpd port master.cf serves on every interface, which is the one
+# the image exposes. A service bound to a single address is left alone: it may
+# be there for something that does not answer this container.
+smtpdPort()
+{
+    local service port
+
+    service=$(postconf -M | awk '$2 == "inet" && $NF == "smtpd" && $1 !~ /:/ { print $1 ; exit }')
+    [ -n "$service" ] || return 1
+
+    port=$(getent services "$service" | awk '{ sub("/.*", "", $2) ; print $2 }')
+    echo "${port:-$service}"
+}
+
+# Whether an smtpd survives long enough to greet a client.
+awaitGreeting()
+{
+    local port="$1" try greeting
+
+    for try in 1 2 3 4 5 ; do
+      # The connection is opened inside a subshell, and the redirection that
+      # silences a refused one is on the substitution rather than on "exec":
+      # "exec ... 2> /dev/null" has no command to apply to, so it would send
+      # this script's own stderr to /dev/null for the rest of the container's
+      # life, taking every message below with it.
+      greeting=$(
+        exec 3<>"/dev/tcp/127.0.0.1/$port" || exit
+        # Short: master accepts at once when an smtpd can run, and holds the
+        # connection open with nothing behind it when one cannot -- it keeps
+        # the socket while it throttles the service it could not start. Five
+        # tries of this is the whole cost of refusing a broken relay.
+        read -t 2 -r line <&3
+        # QUIT rather than dropping the connection, so the one line this
+        # leaves in the log is a disconnect and not a lost connection.
+        printf 'QUIT\r\n' >&3
+        echo "$line"
+      ) 2> /dev/null
+
+      case "$greeting" in 220*) return 0 ;; esac
+      sleep 0.2
+    done
+
+    return 1
+}
+
 startService()
 {
     local name="$1" process="$2"
@@ -351,6 +396,27 @@ fi
 rsyslogd -n &
 rsyslogPid=$!
 supervised="$supervised rsyslogd"
+
+# A running master is not the same as a postfix that can serve. Master binds
+# the port and forks an smtpd per connection, so a setting smtpd rejects when
+# it reads it leaves a relay that listens, accepts, and then kills every
+# session. Nothing else notices: "postconf -e" takes the value without a word,
+# "postfix check" passes, the socket is in /proc and master is running, so the
+# health check reports the container healthy while it relays nothing at all
+# (issue #206).
+#
+# One greeting is what separates the two. It is done here rather than in the
+# health check because it costs a connect in the log: once per container here,
+# every interval there. After rsyslogd so that postfix's own reason -- the
+# "fatal:" line naming the setting -- is in the container log above this.
+smtpdPort=$(smtpdPort)
+if [ -n "$smtpdPort" ] && ! awaitGreeting "$smtpdPort" ; then
+  echo "No smtpd survived a connection on $smtpdPort, which a setting postfix" \
+       "rejects when smtpd reads it will do; refusing to relay. The line above" \
+       "starting \"fatal:\" names it." >&2
+  stopDaemons
+  exit 1
+fi
 
 # rsyslogd is the only one of them that is a child of this script, so the bare
 # "wait" this replaces was watching one daemon out of five and the container

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -191,6 +191,11 @@ def container_log(container):
     return container.get_logs()[0].decode()
 
 
+def container_stderr(container):
+    """What the container refused to do: container_log only takes stdout."""
+    return container.get_logs()[1].decode()
+
+
 def wait_for_log(container, text, timeout=DEFAULT_TIMEOUT):
     """Wait for a line in the container log and return the whole log."""
     return poll_until(lambda: text in container_log(container) and container_log(container),

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -8,9 +8,9 @@ import time
 
 import pytest
 
-from tests.helpers import (container_exec, container_log, exit_code_within, poll_until,
-                           process_running, restart, send, wait_for_file, wait_for_log,
-                           wait_for_smtp)
+from tests.helpers import (container_exec, container_log, container_stderr,
+                           exit_code_within, poll_until, process_running, restart,
+                           send, wait_for_file, wait_for_log, wait_for_smtp)
 
 
 def health(container):
@@ -231,6 +231,31 @@ def test_the_container_stops_when_a_daemon_it_started_exits(daemon, env, postfix
     # second reading that confirms it. It costs nothing when the container
     # does stop, which is the outcome being asserted.
     assert exit_code_within(relay, seconds=15) == 1
+
+
+def test_a_setting_postfix_cannot_serve_with_stops_the_container(postfix_factory):
+    """A relay that listens and kills every session is worse than one that
+    is down: nothing about it looks wrong from outside.
+
+    An empty error_notice_recipient is the reachable case -- the README
+    documents an empty value as the way to clear a default, postconf takes
+    it without a word and "postfix check" passes, but smtpd reads it at the
+    start of every session and dies on it. The master keeps the port open
+    throughout, so the health check has a running master and a listening
+    socket to look at and reports healthy (issue #206).
+    """
+    relay = postfix_factory(env={'POSTFIX_error_notice_recipient': ''},
+                            wait_ready=False)
+
+    # Longer than the daemon cases above: master holds the connection open
+    # with nothing behind it while it throttles the smtpd it could not start,
+    # so each of the five attempts waits out its own read timeout.
+    assert exit_code_within(relay, seconds=25) == 1
+
+    log = container_log(relay) + container_stderr(relay)
+    # Postfix's own reason, which names the setting, and then this image's.
+    assert 'bad string length' in log
+    assert 'No smtpd survived a connection' in log
 
 
 def test_the_chroot_still_works_when_the_queue_is_mounted_from_the_host(

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -10,18 +10,13 @@ import pytest
 
 from testcontainers.community.mailpit import MailpitUser
 
-from tests.helpers import (container_exec, container_log,
+from tests.helpers import (container_exec, container_log, container_stderr,
                            healthcheck_after_stopping, send)
 
 UPSTREAM = '[secrets-upstream]:1025'
 USER, PASSWORD = 'relay', 's3cret'
 SECRET = '/run/secrets/sasl_passwd'
 SASL_PASSWD = f"{UPSTREAM} {USER}:{PASSWORD}\n"
-
-
-def container_stderr(container):
-    """What the container refused to do: container_log only takes stdout."""
-    return container.get_logs()[1].decode()
 
 
 def healthcheck(container):


### PR DESCRIPTION
Closes #206.

A running `master` is not a relay that works. Master binds the port and forks an `smtpd` per connection, so a setting `smtpd` rejects when it reads it leaves a container that listens, accepts, and kills every session.

Nothing noticed. `postconf -e` takes the value without a word, `postfix check` exits 0, le socket est dans `/proc` et `master` tourne -- so the health check, which looks at exactly those two things, calls the container **healthy** while it relays nothing at all. The first thing that finds out is a client, and what it gets is a closed connection.

## The change

Start-up asks postfix for a greeting once and refuses to hand over without one, which is the rule the image already applies to every other daemon:

> A daemon that fails to start at all stops the container instead of relaying mail without the signing or rewriting that was configured

It is done in `run` rather than in `healthcheck` because it costs a connect in the log: **once per container** here, **every interval** there -- against a check whose stated point is to leave the log alone. It runs after rsyslogd so postfix's own `fatal:` line naming the setting is in the log above the refusal, rather than lost before logging starts.

Only the first `smtpd` inet service `master.cf` serves on every interface is asked. One bound to a single address is left alone: it may be there for something that does not answer this container.

## One thing worth reading closely

The connection is opened in a subshell, and the redirection silencing a refused one is on the substitution, not on `exec`:

```bash
greeting=$(
  exec 3<>"/dev/tcp/127.0.0.1/$port" || exit
  read -t 2 -r line <&3
  printf 'QUIT\r\n' >&3
  echo "$line"
) 2> /dev/null
```

`exec ... 2> /dev/null` has no command to apply to, so it sends **the script's own stderr** to `/dev/null` for the rest of the container's life. That is not hypothetical: the first version of this did exactly that, and the refusal it was meant to print vanished -- along with everything the supervision loop would ever have had to say. It took an instrumented build to find, because the container still exited 1, silently.

The read timeout is short because master accepts at once when an `smtpd` can run, and holds the connection open with nothing behind it when one cannot: it keeps the socket while it throttles the service it failed to start. Five tries is about eleven seconds, the whole cost of refusing a broken relay.

## Verification

Run against the built image:

| | result |
|---|---|
| Relay with an empty `POSTFIX_error_notice_recipient` | **exits 1** 15s in, with postfix's `fatal: bad string length 0 < 1: error_notice_recipient =` and then the refusal |
| Normal relay | comes up, health check passes, **two** extra log lines: a connect and a clean disconnect (`quit=1 commands=1`) |
| New test against master's `run` | **fails** |
| Whole suite | **225 passed, 1 skipped** in 2m15s |

`container_stderr` moves to `tests/helpers.py` now that a second file wants it. The README's health-check section gains a paragraphe pour la nouvelle règle.

---
_Generated by [Claude Code](https://claude.ai/code)_