### PR TITLE
Say how to turn off a default the image ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ Postfix [configuration options](http://www.postfix.org/postconf.5.html) can be s
 using `POSTFIX_<name>` environment variables. See [Dockerfile](Dockerfile) for default
 configuration. You probably want to set `POSTFIX_myhostname` (the FQDN used by 220/HELO).
 
+Setting one of these to an **empty** value clears the parameter rather than
+being skipped, which is the only way to turn off a default the image ships:
+`POSTFIX_smtp_tls_security_level=` leaves the relay with no opportunistic TLS
+at all, where leaving the variable out keeps the Dockerfile's `may`.
+
+Not every parameter accepts an empty value, though, and postfix does not say so
+when it is written: `postconf` takes it, `postfix check` passes, and the daemon
+that reads it dies when it does. `error_notice_recipient` is one of those. The
+container asks postfix for a greeting before handing over, so it stops with the
+postfix `fatal:` line naming the parameter instead of coming up unable to
+relay — but the value is still yours to get right.
+
 Note that `POSTFIX_myhostname` will change the postfix option
 [myhostname](http://www.postfix.org/postconf.5.html#myhostname). The image ships
 `POSTFIX_myhostname=hostname`, so unless you set it yourself a running container


### PR DESCRIPTION
Setting a `POSTFIX_` variable to an **empty** value clears the parameter instead of being skipped, which is the only way to switch off one of the defaults the Dockerfile ships. The suite has relied on that since the config tests landed -- `test_myhostname_is_what_the_relay_calls_itself` clears `smtp_tls_security_level` to check the banner without TLS -- and a comment in `tests/test_config.py` is the only place it is written down:

> An empty value clears a Dockerfile default instead of being skipped, which is the only way to turn one of them off.

A user reading the README has no way to know it works. The image ships eight `POSTFIX_` defaults and wanting one of them off is not exotic.

The caveat belongs with it, and is the reason this is being written now. Postfix does not accept an empty value for every parameter, and says nothing when one is written: `postconf` takes it, `postfix check` passes, and the daemon that reads it dies when it does. `error_notice_recipient` is one of those, reachable from the documented `POSTMASTER_ADDRESS` by opting one class back out. Since #210 the container refuses to hand over rather than coming up unable to relay, so the failure is loud -- but the reader should know the class of parameter exists before meeting one.

## Verification

Documentation only, but the claims are checked rather than assumed. On the built image:

| | result |
|---|---|
| `POSTFIX_smtp_tls_security_level=` | `smtp_tls_security_level` is empty, container up and healthy |
| variable left out | `smtp_tls_security_level = may` |

## A correction

While writing this I found that I had the attribution wrong in #206: that issue says *"`README.md` documents the empty value as the way to turn off a Dockerfile default"*. It does not, and did not -- the only statement of the contract was the test comment quoted above. The bug #206 described and #210 fixed is unaffected: it reproduces regardless of where the behaviour is documented. But the sentence in that issue est fausse, and this pull request is what makes it true.

---
_Generated by [Claude Code](https://claude.ai/code)_