### PR TITLE
Ask mailpit whether it is up more often than once a second

### DIFF
--- a/tests/fixtures/mailpit.py
+++ b/tests/fixtures/mailpit.py
@@ -1,10 +1,33 @@
+import functools
 import time
 
 import docker
 import pytest
 import requests
 
+import testcontainers.community.mailpit as mailpit_module
+
 from testcontainers.community.mailpit import MailpitContainer
+
+# Ask the container whether it is up more often than once a second.
+#
+# MailpitContainer.start() waits for a line in the log, and looks for it at the
+# library's default interval of one second. Mailpit is ready 0.19s after docker
+# starts it, measured, so the first look is too early and the second one is most
+# of a second late: 1.33s to start one against 0.29s when it is asked more
+# often, and the suite starts about nine of them.
+#
+# The wait itself is not changed -- same log line, same timeout, and it still
+# returns the moment the line is there rather than after a fixed delay. Only how
+# often it looks.
+#
+# Done by handing the library's own function a different default rather than by
+# reimplementing start() in a subclass: if a release stops going through
+# wait_for_logs, this quietly stops applying and the suite is merely as slow as
+# it is today, where a start() of our own would silently skip whatever that
+# release had added to theirs.
+mailpit_module.wait_for_logs = functools.partial(
+    mailpit_module.wait_for_logs, interval=0.05)
 
 from tests.conftest import print_log_on_failure
 from tests.helpers import once_across_workers, poll_until


### PR DESCRIPTION
Part of #208, and the only part of it worth doing -- see below.

`MailpitContainer.start()` waits for a line in the container log through the library's
`wait_for_logs`, whose default interval is one second. Mailpit is ready **0.19s** after docker
starts it (measured by polling the log every 20ms), so the first look is too early and the
second is most of a second late.

Asking every 50ms instead:

| | |
| --- | --- |
| starting one mailpit container | 1.33s -> **0.29s** |
| whole suite, one process | 497s -> **491s** |
| whole suite, four workers | ~148s -> **~140s** (three runs: 142, 140, 138) |

The 6s serial is exactly the six mailpit containers a serial run starts, at 1.04s each.

**This is not a shortened sleep.** Same log line, same timeout, and the wait still returns the
moment the line appears rather than after any fixed delay. Only how often it looks changes.

**It fails safe.** The library's own function is handed a different default rather than
`start()` being reimplemented in a subclass. A subclass would have to call
`DockerContainer.start` itself and then wait, silently skipping whatever a later release adds
to `MailpitContainer.start`. This way, a release that stops going through `wait_for_logs` makes
the change stop applying and the suite is merely as slow as it is today.

225 passed, 1 skipped over four runs.

## What else #208 listed, and why it is not here

**The other reading poll.** `test_healthcheck.run_healthcheck` sleeps 0.5s between attempts.
Taking it to 0.1s moved the file from 49s to 49s: the loop almost never goes round twice.
Measured and left alone.

**The 4096-bit RSA key** `MailpitContainer.__init__` generates for TLS the tests never use:
0.16s median, ~1.4s across a run. #208 claimed 3.8s. Not worth replacing their certificate
generation.

**The container pooling**, which is most of #208. Every `postfix_factory` call site was judged
against the read/mutate rule and each candidate was then attacked adversarially. Eighteen can
share a pooled relay -- but **twelve of those remove no container start at all**, and the six
that do are worth **16.5s serial**, none of them in `test_lifecycle.py` (104.2s), the longest
file. At four workers the run is bound by balancing (491s/4 = 123s), so 16.5s serial est about
**4s of wall clock, under the run-to-run noise**.

Six tests changed, each carrying a small flakiness risk, for a gain that cannot be measured.
Not done. #208 predicted the payoff would be smaller than its table suggested; this is how much
smaller.

---
_Generated by [Claude Code](https://claude.ai/code)_