### PR TITLE
Keep Dependabot's push out of the registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,12 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       -
+        # Dependabot pushes its branch before opening the pull request, and a
+        # run it triggers can only read Dependabot secrets, never the Actions
+        # secrets below. Logging in would fail, so skip the registry for it and
+        # let the build alone prove the bump.
         name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -81,7 +85,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ display `name:`, so on an ordinary pull request it appears as a skipped
 
 | Check | From | What it does |
 | --- | --- | --- |
-| **Build Image** | `ci.yml` | buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`. Nothing is pushed on a PR — the DockerHub login is skipped, and the build step sets `push: ${{ github.event_name != 'pull_request' }}` — but the build has to succeed on **all three** architectures. This is the gate that catches architecture-specific packaging problems. |
+| **Build Image** | `ci.yml` | buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`. Nothing is pushed on a PR — the DockerHub login is skipped, and the build step sets `push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}` — but the build has to succeed on **all three** architectures. The `dependabot[bot]` half of that condition covers the branch push Dependabot makes before opening its pull request: such a run reads Dependabot secrets only, so the Actions secrets the login needs arrive empty. This is the gate that catches architecture-specific packaging problems. |
 | **Pytest** | `test.yml` | `ubuntu-latest`, Python 3.13, `pip install -r tests/requirements.txt`, `pytest --junitxml=junit/test-results.xml`. |
 | **Pytest (arm64)** | `test.yml` | The same, natively, on `ubuntu-24.04-arm`. |
 | **Event File** | `test.yml` | Uploads the triggering event payload for the reporter. |


### PR DESCRIPTION
Closes #214.

Dependabot pushes its branch before opening the pull request, and that push starts `ci`. A run Dependabot triggers can read **Dependabot** secrets only, never the Actions secrets, so `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` arrive empty, the login fails, and the job goes red.

The red lands on the same commit the pull request reports, so the `Build Image` check the master ruleset requires would fail on every Dependabot pull request, and the auto-merge added in #168 would never complete.

Nothing has hit this yet, and the reason is worth stating: the base image is on `trixie-20260824-slim`, which is the newest Debian slim tag, and every action is on its latest major, so Dependabot has had nothing to open since its config landed. The first bump it does open is where this would show up.

The fix skips the login for those runs and stops the branch build from pushing. The image is still built, which is the part that says whether the bump is good; only the registry is left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8f8cYHQQkqat1cXsJgRFN