### PR TITLE
Check the start-up checks against the relays that have them

### DIFF
--- a/run
+++ b/run
@@ -31,17 +31,39 @@ smtpdPort()
 {
     local service port
 
-    service=$(postconf -M | awk '$2 == "inet" && $NF == "smtpd" && $1 !~ /:/ { print $1 ; exit }')
+    # $8 is master.cf's command column. The last field is not it: an entry
+    # carries its "-o" options after the command, which is what
+    # POSTFIXMASTER_ variables are for, and reading $NF there matches nothing.
+    service=$(postconf -M | awk '$2 == "inet" && $8 == "smtpd" && $1 !~ /:/ { print $1 ; exit }')
     [ -n "$service" ] || return 1
 
     port=$(getent services "$service" | awk '{ sub("/.*", "", $2) ; print $2 }')
     echo "${port:-$service}"
 }
 
+# The address to greet on. Loopback answers unless inet_interfaces was
+# narrowed to addresses that do not include it, in which case the first one it
+# names does: a relay is free to serve only the address its clients reach it
+# on, and greeting loopback there would refuse to start a relay that works.
+smtpdAddress()
+{
+    local interfaces entry first
+
+    interfaces=$(postconf -h inet_interfaces)
+    for entry in ${interfaces//,/ } ; do
+      case "$entry" in
+        all|loopback-only|127.0.0.1|localhost) echo 127.0.0.1 ; return ;;
+      esac
+      [ -n "$first" ] || first="$entry"
+    done
+
+    echo "${first:-127.0.0.1}"
+}
+
 # Whether an smtpd survives long enough to greet a client.
 awaitGreeting()
 {
-    local port="$1" try greeting
+    local address="$1" port="$2" try greeting
 
     for try in 1 2 3 4 5 ; do
       # The connection is opened inside a subshell, and the redirection that
@@ -50,7 +72,7 @@ awaitGreeting()
       # this script's own stderr to /dev/null for the rest of the container's
       # life, taking every message below with it.
       greeting=$(
-        exec 3<>"/dev/tcp/127.0.0.1/$port" || exit
+        exec 3<>"/dev/tcp/$address/$port" || exit
         # Short: master accepts at once when an smtpd can run, and holds the
         # connection open with nothing behind it when one cannot -- it keeps
         # the socket while it throttles the service it could not start. Five
@@ -296,7 +318,10 @@ stopDaemons()
     wait "$rsyslogPid" 2> /dev/null
 }
 
-trap 'stopping=1 ; stopDaemons' SIGTERM SIGINT
+# Exits from the handler rather than only flagging the stop: during start-up
+# the script would otherwise carry on from where the signal interrupted it and
+# report the daemons it had just stopped as daemons that would not start.
+trap 'stopping=1 ; stopDaemons ; exit 0' SIGTERM SIGINT
 if [ ! -z "$OPENDKIM_DOMAINS" ] ; then
   dkimConfig
   startService opendkim opendkim
@@ -410,8 +435,9 @@ supervised="$supervised rsyslogd"
 # every interval there. After rsyslogd so that postfix's own reason -- the
 # "fatal:" line naming the setting -- is in the container log above this.
 smtpdPort=$(smtpdPort)
-if [ -n "$smtpdPort" ] && ! awaitGreeting "$smtpdPort" ; then
-  echo "No smtpd survived a connection on $smtpdPort, which a setting postfix" \
+smtpdAddress=$(smtpdAddress)
+if [ -n "$smtpdPort" ] && ! awaitGreeting "$smtpdAddress" "$smtpdPort" ; then
+  echo "No smtpd survived a connection on $smtpdAddress:$smtpdPort, which a setting postfix" \
        "rejects when smtpd reads it will do; refusing to relay. The line above" \
        "starting \"fatal:\" names it." >&2
   stopDaemons

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -286,3 +286,65 @@ def test_the_chroot_still_works_when_the_queue_is_mounted_from_the_host(
 
     assert relay.exec(["test", "-S", "/var/spool/postfix/dev/log"]).exit_code == 0
     assert 'cannot create' not in container_log(relay)
+
+
+def test_the_greeting_check_still_covers_a_customised_smtp_service(postfix_factory):
+    """A master.cf entry carries its options after the command.
+
+    Adding "-o" options to smtp/inet is what POSTFIXMASTER_ is documented for,
+    and it moves the command away from the end of the line. Reading the last
+    field to find the smtpd to greet matches nothing then, no probe runs, and
+    the check above passes by not happening -- on the relays that were
+    customised, which are the ones most likely to have been customised wrong.
+    """
+    relay = postfix_factory(
+        env={
+            'POSTFIX_error_notice_recipient': '',
+            'POSTFIXMASTER_smtp__inet':
+                'smtp inet n - y - - smtpd -o smtpd_client_restrictions=permit_mynetworks,reject',
+        },
+        wait_ready=False)
+
+    assert exit_code_within(relay, seconds=25) == 1
+    assert 'No smtpd survived a connection' in container_log(relay) + container_stderr(relay)
+
+
+def test_a_relay_that_does_not_serve_loopback_still_starts(postfix_factory, mailpit):
+    """inet_interfaces names the addresses the relay serves, loopback or not.
+
+    Greeting 127.0.0.1 regardless refuses to start a relay that is working
+    for every client it has, and tells its operator to look for a postfix
+    "fatal:" line that was never written.
+    """
+    relay = postfix_factory(env={'POSTFIX_inet_interfaces': 'relay-off-loopback'},
+                            kwargs={'hostname': 'relay-off-loopback'})
+
+    # The probe is the last thing start-up does, and it takes its five
+    # attempts before giving up: a connection accepted through the published
+    # port only says the master is up, so the relay is given the time to
+    # refuse before it is called started.
+    assert exit_code_within(relay, seconds=20) is None
+
+    send(relay, subject='off loopback')
+
+    assert mailpit.wait_for_message('off loopback')
+
+
+def test_a_stop_during_start_up_is_not_reported_as_a_failure(postfix_factory):
+    """SIGTERM before the relay is up is still a stop the operator asked for.
+
+    Generating several keys holds start-up open long enough for the signal to
+    land in it. Should it land after start-up instead, this passes on the
+    ordinary path rather than failing: what it must never do is report a
+    daemon that would not start.
+    """
+    relay = postfix_factory(
+        env={'OPENDKIM_DOMAINS': ' '.join(f"d{n}.example" for n in range(8))},
+        wait_ready=False)
+    wrapped = relay.get_wrapped_container()
+
+    time.sleep(1)
+    wrapped.stop(timeout=30)
+
+    assert wrapped.wait(timeout=30)['StatusCode'] == 0
+    assert 'did not start' not in container_stderr(relay)


### PR DESCRIPTION
Closes #221

Three defects in the start-up path, all of them in the guard added for issue #206, all of them only reachable on a relay that was configured rather than left as it ships.

The port to greet is read as the last field of the master.cf line. A service carries its "-o" options after the command, which is exactly what the POSTFIXMASTER_ variables documented in the README are for, so on any relay whose smtp service was customised the awk matched nothing, no probe ran and the guard passed by not happening -- silently, on the relays most likely to have been configured wrong. It reads the command column now.

The probe then connects to 127.0.0.1 whatever inet_interfaces says. A relay told to serve only the address its clients reach it on is refused: five connections refused, the container exits 1, and its operator is told to look for a "fatal:" line postfix never wrote. It greets the first address inet_interfaces names, and loopback whenever that list includes it or is one of the two keywords that do.

Finally, the shutdown trap flagged the stop but let start-up carry on from where the signal interrupted it, so a container stopped while it was still starting would go on to report the daemons it had just stopped as daemons that would not start: exit 1, "did not start", for a stop the operator asked for. Under an on-failure restart policy that is a restart. The handler exits, which is what the supervision loop below already does for the same signal.

Tested on the built image: three tests in tests/test_lifecycle.py, each of which fails on master and passes here -- a customised smtp service still refuses to relay when smtpd cannot serve, a relay that does not listen on loopback starts and delivers, and a stop during start-up exits 0 without claiming a daemon was missing. The suite is 228 passed, 1 skipped.


Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ