### PR TITLE
Refuse to relay when a DKIM key could not be generated

### DIFF
--- a/run
+++ b/run
@@ -151,8 +151,20 @@ dkimConfig()
       txtFile="$domainDir/$selector.txt"
       if [ ! -f "$privateFile" ] ; then
         echo "No DKIM private key found for selector '$selector' in domain '$domain'. Generating one now..."
-        mkdir -p "$domainDir"
-        opendkim-genkey -D "$domainDir" --selector=$selector --domain=$domain --append-domain
+        # A key that could not be written is worse than no DKIM at all: the
+        # tables below would name it, opendkim would start without being able
+        # to load it, and the milter would answer every message with a
+        # tempfail -- a relay that accepts nothing while it reports healthy.
+        if ! mkdir -p "$domainDir" \
+           || ! opendkim-genkey -D "$domainDir" --selector="$selector" \
+                --domain="$domain" --append-domain \
+           || [ ! -f "$privateFile" ] ; then
+          echo "Could not generate a DKIM key for selector '$selector' in" \
+               "domain '$domain': /etc/opendkim/keys has to be writable, or" \
+               "hold the keys already. Refusing to relay without the signing" \
+               "that was asked for." >&2
+          exit 1
+        fi
       fi
 
       # Ensure strict permissions required by opendkim

--- a/tests/test_dkim.py
+++ b/tests/test_dkim.py
@@ -9,7 +9,8 @@ import re
 import dkim
 import pytest
 
-from tests.helpers import (container_exec, container_log, dkim_dns_record, image_run,
+from tests.helpers import (container_exec, container_log, container_stderr,
+                           dkim_dns_record, exit_code_within, image_run,
                            listening_sockets, postconf, restart, send)
 
 KEY_PATH = '/etc/opendkim/keys/example.com/sel1.private'
@@ -269,9 +270,17 @@ def test_the_record_printed_on_start_up_is_the_one_to_publish(signing):
 
     assert record.startswith('v=DKIM1;')
     assert 'p=' in record
-    # The log carries the file, quoted strings and all.
-    for part in re.findall(r'"([^"]*)"', record):
-        assert part in log or record in log
+    # The log carries the file as opendkim-genkey wrote it, which is the
+    # record split over quoted strings the way a zone file wants it. Taken
+    # from the file rather than from the joined record: dkim_dns_record has
+    # already removed the quotes, so looking for them in its result found
+    # nothing to check and the loop never ran.
+    published = container_exec(signing, ["cat", "/etc/opendkim/keys/example.com/sel1.txt"])
+    chunks = re.findall(r'"([^"]*)"', published)
+
+    assert chunks
+    for chunk in chunks:
+        assert chunk in log
 
 
 def test_the_published_key_is_the_public_half_of_the_generated_one(signing):
@@ -401,3 +410,21 @@ def test_a_signed_message_still_verifies_after_its_envelope_is_rewritten(
     assert message['From']['Address'] == 'sender@example.com'
     assert verifies(mailpit.raw(message['ID']),
                     dkim_dns_record(relay, 'example.com', 'sel1'))
+
+
+def test_a_key_that_could_not_be_generated_stops_the_container(postfix_factory):
+    """Signing that cannot happen has to stop the relay, not the mail.
+
+    With the key directory in the way -- a read-only keys volume is the same
+    case -- the tables still named a key that was never written, opendkim
+    started without being able to load it, and the milter answered every
+    message with "451 4.7.1 Service unavailable": a relay that accepts no
+    mail at all while docker reports it healthy.
+    """
+    relay = postfix_factory(
+        env={'OPENDKIM_DOMAINS': 'example.com'},
+        files={'/etc/opendkim/keys/example.com': "not a directory\n"},
+        wait_ready=False)
+
+    assert exit_code_within(relay, seconds=20) == 1
+    assert 'Could not generate a DKIM key' in container_stderr(relay)


### PR DESCRIPTION
Closes #222

opendkim-genkey's exit status is not looked at, and neither is the key it was meant to write. When it fails -- a read-only keys volume, which is an ordinary way to hand private keys to a container, or a full or otherwise unwritable one -- start-up carries on: the KeyTable and SigningTable name a key that does not exist, opendkim starts, and the only trace is a "cat: ... No such file" line under the script's own "DNS records:" heading.

What that relay then does is worse than relaying unsigned. opendkim loads no key, so the milter answers every message with a tempfail, and postfix rejects each one with "451 4.7.1 Service unavailable - try again later" while the health check reports the container healthy: a relay that accepts no mail at all and says nothing is wrong. Verified on the built image before the change, with /etc/opendkim/keys mounted read-only.

It now stops the way the rest of the script does when a daemon cannot do what it was configured for, naming the directory that has to be writable.

Also fixes a test that could not fail. "the record printed on start-up is the one to publish" looked for the record's quoted chunks in the log, but took them from dkim_dns_record, which has already stripped the quotes and joined the parts -- so the pattern found nothing, the loop body never ran, and the one test for "DNS records to configure can be found in the container log" asserted nothing beyond what the two lines above it check. It reads the chunks from the file opendkim-genkey wrote, and asserts there are some.

Tested on the built image: the new test fails on master, where the container comes up and stays healthy, and passes here. The suite is 226 passed, 1 skipped.


Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ