### PR TITLE
Make the README's examples ones that run

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,17 @@ docker run -e POSTFIX_myhostname=smtp.domain.tld mwader/postfix-relay
 
 ### Using docker-compose
 ```
-app:
-  # use hostname "smtp" as SMTP server
+services:
+  app:
+    image: your-app
+    # sends its mail to the host "smtp", which is the service below
 
-smtp:
-  image: mwader/postfix-relay
-  restart: always
-  environment:
-    - POSTFIX_myhostname=smtp.domain.tld
-    - OPENDKIM_DOMAINS=smtp.domain.tld
+  smtp:
+    image: mwader/postfix-relay
+    restart: always
+    environment:
+      - POSTFIX_myhostname=smtp.domain.tld
+      - OPENDKIM_DOMAINS=smtp.domain.tld
 ```
 
 <p align="right">(<a href="#top">back to top</a>)</p>
@@ -202,19 +204,20 @@ To hand mail over to a provider instead of delivering it yourself, point
 `POSTFIX_relayhost` at it and give postfix the credential in a lookup table:
 
 ```
-smtp:
-  image: mwader/postfix-relay
-  environment:
-    - POSTFIX_myhostname=smtp.domain.tld
-    - POSTFIX_relayhost=[smtp.provider.tld]:587
-    - POSTFIX_smtp_sasl_auth_enable=yes
-    - POSTFIX_smtp_sasl_password_maps=hash:/etc/postfix/sasl_passwd
-    - POSTFIX_smtp_sasl_security_options=noanonymous
-    # Refuse to send at all if the connection cannot be encrypted
-    - POSTFIX_smtp_tls_security_level=encrypt
-    - POSTMAP_sasl_passwd_FILE=/run/secrets/sasl_passwd
-  secrets:
-    - sasl_passwd
+services:
+  smtp:
+    image: mwader/postfix-relay
+    environment:
+      - POSTFIX_myhostname=smtp.domain.tld
+      - POSTFIX_relayhost=[smtp.provider.tld]:587
+      - POSTFIX_smtp_sasl_auth_enable=yes
+      - POSTFIX_smtp_sasl_password_maps=hash:/etc/postfix/sasl_passwd
+      - POSTFIX_smtp_sasl_security_options=noanonymous
+      # Refuse to send at all if the connection cannot be encrypted
+      - POSTFIX_smtp_tls_security_level=encrypt
+      - POSTMAP_sasl_passwd_FILE=/run/secrets/sasl_passwd
+    secrets:
+      - sasl_passwd
 
 secrets:
   sasl_passwd:
@@ -312,7 +315,7 @@ This parameter is handled by Debian base image.
 
 ```
 environment:
-  ...
+  # ...
   - TZ=Europe/Prague
 ```
 
@@ -487,7 +490,7 @@ keys to persist indefinitely, make sure to mount a volume for
 `/etc/opendkim/keys`, otherwise they will be destroyed when the container is
 removed.
 
-DNS records to configure can be found in the container log or by running `docker exec <container> sh -c 'cat /etc/opendkim/keys/*/*.txt` you should see something like this:
+DNS records to configure can be found in the container log or by running `docker exec <container> sh -c 'cat /etc/opendkim/keys/*/*.txt'` you should see something like this:
 ```bash
 $ docker exec 7996454b5fca sh -c 'cat /etc/opendkim/keys/*/*.txt'
 
@@ -543,7 +546,7 @@ By default container only logs to stdout. If you also wish to log `mail.*` messa
 
 ```
 environment:
-  ...
+  # ...
   - RSYSLOG_LOG_TO_FILE=yes
   - RSYSLOG_TIMESTAMP=yes
 volumes:
@@ -556,7 +559,7 @@ you can change it to [another template](https://www.rsyslog.com/doc/v8-stable/co
 
 ```
 environment:
-  ...
+  # ...
   - RSYSLOG_REMOTE_HOST=my.remote-syslog-server.com
   - RSYSLOG_REMOTE_PORT=514
   - RSYSLOG_REMOTE_TEMPLATE=RSYSLOG_ForwardFormat
@@ -740,6 +743,8 @@ against a native run.
 | `test_healthcheck.py` | The health check, against relays with a daemon taken away |
 | `test_lifecycle.py` | Starting, restarting, stopping, and the mail that is in the queue meanwhile |
 | `test_capabilities.py` | Relaying with everything docker grants by default taken away but the documented set |
+| `test_secrets.py` | Configuration read from a file instead of the environment, and what the health check still expects |
+| `test_qshape.py` | The queue tool the troubleshooting section has users run |
 
 Use the `postfix` fixture for a relay with the default configuration,
 `postfix_shared` for a configuration several tests read the same way, and

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -5,6 +5,8 @@ it hands the work to unprivileged users itself and needs very little of what
 docker grants a container by default.
 """
 
+import time
+
 import pytest
 
 from tests.helpers import container_exec, send
@@ -55,3 +57,21 @@ def test_dropping_everything_stops_the_container(postfix_factory):
     relay = postfix_factory(kwargs={'cap_drop': ['ALL']}, wait_ready=False)
 
     assert relay.get_wrapped_container().wait(timeout=60)['StatusCode'] == 1
+
+
+def test_the_hardened_relay_stops_gracefully(hardened_relay):
+    """Stopping is the operation most likely to miss a capability.
+
+    "stopDaemons" signals daemons that dropped to their own users and waits
+    for them, and the README says a graceful stop is one of the things the
+    set above was checked against.
+    """
+    wrapped = hardened_relay.get_wrapped_container()
+
+    started = time.monotonic()
+    wrapped.stop(timeout=30)
+    elapsed = time.monotonic() - started
+
+    wrapped.reload()
+    assert wrapped.attrs['State']['ExitCode'] == 0
+    assert elapsed < 10, f"stopping took {elapsed:.1f}s, the SIGTERM trap did not run"


### PR DESCRIPTION
The two whole-file compose examples are in the format Compose v1 used, with the services at the top level. Docker rejects them before starting anything:

    $ docker compose -f readme-example.yml config
    validating readme-example.yml: additional properties 'app', 'smtp' not allowed

That is the first thing a new user copies, and the one recipe that carries a provider password. Both are now under a "services:" key, with the top-level "secrets:" block left where it is, and the app service in the first one has an image so that the file is complete rather than a service with nothing in it. Checked with "docker compose config", which accepts both and rejects what was there before.

Three other things in the same vein:

The command for reading the DNS records to publish is missing its closing quote, so pasting it leaves the reader at a continuation prompt at the moment they are trying to publish a key.

Three environment blocks use a bare "..." to mean "your other entries here". It is the one form of elision YAML does not reject outright -- it ends the document -- so a reader who leaves it in gets an error about the key above it instead. Written as a comment now.

The table of test files had fallen two behind the suite, so a contributor looking for where secrets-from-files or qshape is covered would conclude they are not.

The capability section says relaying, signing, rewriting, the health check and a graceful stop were all checked against the documented set, and a test covered all of them but the stop -- which is the one most likely to notice a missing capability, since it signals daemons that dropped to their own users. The test is now there rather than the claim being trimmed.

Tested on the built image: tests/test_capabilities.py is 4 passed.


Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ