### PR TITLE
Offer only the authentication mechanisms that can succeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,8 +413,12 @@ volumes:
   - /your_local_path/pam_smtp:/etc/pam.d/smtp
 ```
 
-The generated `smtpd.conf` offers `CRAM-MD5 DIGEST-MD5 LOGIN PLAIN`; a mounted
-one saying `mech_list: PLAIN` is what the relay then advertises.
+The generated `smtpd.conf` offers `LOGIN PLAIN`, the two mechanisms that hand
+`saslauthd` a password to check: `CRAM-MD5` and `DIGEST-MD5` prove knowledge of
+a password without sending it, which needs a secret this check never has, so
+offering them only makes clients that pick the strongest mechanism fail. A
+mounted `smtpd.conf` saying `mech_list: PLAIN` is what the relay then
+advertises instead.
 
 `SASL_Passwds` still has to be set to something non-empty, whatever those files
 contain. It is what switches the whole SASL block on, and `saslauthd` is started

--- a/run
+++ b/run
@@ -314,10 +314,16 @@ fi
 # Checking for user specified passwd file
 if [ ! -z "$SASL_Passwds" ] ; then
   # Creating auth settings file
+  #
+  # Only the mechanisms that hand saslauthd a password to check are offered:
+  # it verifies a password, and CRAM-MD5 and DIGEST-MD5 prove knowledge of one
+  # without sending it, which needs the secret this check never has. Offering
+  # them means a client that picks the strongest mechanism on the list -- what
+  # msmtp and others do -- fails against a relay that is configured correctly.
   if [ ! -e /etc/postfix/sasl/smtpd.conf ] ; then
     cat <<'EOF' > /etc/postfix/sasl/smtpd.conf
 pwcheck_method: saslauthd
-mech_list: CRAM-MD5 DIGEST-MD5 LOGIN PLAIN
+mech_list: LOGIN PLAIN
 EOF
   fi
   

--- a/tests/test_sasl.py
+++ b/tests/test_sasl.py
@@ -12,8 +12,8 @@ import pytest
 
 from testcontainers.community.mailpit import MailpitUser
 
-from tests.helpers import (container_exec, container_log, restart, send,
-                           smtp_connect, wait_for_log)
+from tests.helpers import (container_exec, container_log, esmtp_features, restart,
+                           send, smtp_connect, wait_for_log)
 
 PASSWD_FILE = '/etc/postfix/sasl/sasl_passwds'
 USER, PASSWORD = 'myuser', 'mypassword'
@@ -147,8 +147,8 @@ def test_mounted_sasl_configuration_is_not_overwritten(postfix_image, postfix_fa
 
     with smtp_connect(relay) as smtp:
         smtp.ehlo()
-        # The generated file would have offered CRAM-MD5, DIGEST-MD5 and LOGIN
-        # as well, so the mounted mech_list is the one in use.
+        # The generated file would have offered LOGIN as well, so the
+        # mounted mech_list is the one in use.
         assert smtp.esmtp_features['auth'].split() == ['PLAIN']
 
         smtp.user, smtp.password = USER, PASSWORD
@@ -266,14 +266,17 @@ def test_the_generated_pam_profile_reads_the_password_file(authenticated_relay):
 
 def test_the_generated_sasl_configuration_offers_the_documented_mechanisms(
         authenticated_relay):
-    """The two that work with a PAM password check are offered along with
-    the two that cannot: a client picking CRAM-MD5 first is why the tests
-    name the mechanism instead of letting the library choose."""
+    """Only the two a PAM password check can answer.
+
+    CRAM-MD5 and DIGEST-MD5 were offered as well, which is why the tests
+    below name the mechanism instead of letting the library choose: a client
+    that picks the strongest one on offer never got past the challenge.
+    """
     configuration = container_exec(
         authenticated_relay, ["cat", "/etc/postfix/sasl/smtpd.conf"])
 
     assert 'pwcheck_method: saslauthd' in configuration
-    assert 'mech_list: CRAM-MD5 DIGEST-MD5 LOGIN PLAIN' in configuration
+    assert 'mech_list: LOGIN PLAIN' in configuration
 
 
 def test_the_upstream_password_never_reaches_the_log(postfix_shared):
@@ -295,3 +298,16 @@ def test_the_upstream_password_is_not_readable_by_every_user(postfix_shared):
     relay = postfix_shared(env=UPSTREAM_CREDENTIALS)
 
     assert container_exec(relay, "stat -c %a /etc/postfix/sasl_passwd").strip() == '600'
+
+
+def test_only_the_mechanisms_that_can_authenticate_are_offered(authenticated_relay):
+    """saslauthd is handed a password and checks it.
+
+    CRAM-MD5 and DIGEST-MD5 prove knowledge of a password without sending
+    one, so they cannot be checked that way and can only ever fail. A client
+    that picks the strongest mechanism offered rather than falling back
+    through the list then fails against a relay set up exactly as documented.
+    """
+    _, _, features = esmtp_features(authenticated_relay)
+
+    assert sorted(features['auth'].split()) == ['LOGIN', 'PLAIN']


### PR DESCRIPTION
The generated /etc/postfix/sasl/smtpd.conf advertises CRAM-MD5, DIGEST-MD5, LOGIN and PLAIN. Two of those cannot authenticate anyone here: saslauthd is handed a password and checks it, while CRAM-MD5 and DIGEST-MD5 prove knowledge of a password without sending one, which needs a shared secret this check never has. On the image as it stands they get as far as a challenge and then fail:

    postfix/smtpd: warning: SASL CRAM-MD5 authentication failed:
    bad protocol / cancel, sasl_username=(unavailable)

Whether that matters depends on the client. One that falls back through the list, as python's smtplib does, ends up on PLAIN and works, which is why the setup passes its tests; one that picks the strongest mechanism offered, as msmtp does, gets 535 against a relay configured exactly as the README documents. The suite knew: every test that authenticates names its mechanism rather than letting the library choose, and the test pinning the generated file said so in its docstring.

The generated file now offers LOGIN and PLAIN. Nobody can be authenticating with the other two today, since they cannot complete, and a mounted smtpd.conf is untouched as before -- that is still how a different check, and a different mech_list, is put in place.

Tested on the built image: a new test reads what the relay advertises on the wire rather than what the file says, and fails on master where four mechanisms are offered. The suite is 226 passed, 1 skipped.


Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ