### PR TITLE
Let dependabot update the pinned test dependencies, and document RSYSLOG_TIMESTAMP

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,5 @@
 # Automatic dependency update pull requests
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
-#
-# tests/requirements.txt pins no versions, so a pip ecosystem would have
-# nothing to bump and is left out.
 
 version: 2
 updates:
@@ -41,3 +38,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  # The pinned test dependencies. They are exact pins now, so nothing moves
+  # them on its own, and the suite is what says whether a bump is safe: every
+  # one of these pull requests runs it.
+  - package-ecosystem: pip
+    directory: /tests
+    schedule:
+      interval: weekly

--- a/README.md
+++ b/README.md
@@ -539,7 +539,28 @@ mail.
 
 <!-- LOGGING -->
 ## Logging
-By default container only logs to stdout. If you also wish to log `mail.*` messages to file on persistent volume, you can do something like:
+By default container only logs to stdout.
+
+`RSYSLOG_TIMESTAMP` decides what those lines look like. It defaults to `no`,
+which leaves them as the bare message:
+
+```
+postfix/smtpd[195]: connect from unknown[172.18.0.1]
+```
+
+Docker records a timestamp for every line it collects, so `docker logs -t`
+still shows one and nothing is lost. Set it to `yes` when something reading the
+log parses the message itself and expects a timestamp and a hostname in it:
+
+```
+2026-08-04T16:37:42.344044+00:00 f5ffdf0ff6bf postfix/smtpd[195]: connect from unknown[172.18.0.1]
+```
+
+It applies to the container log and to `/var/log/mail.log`, but not to a
+`.conf` file of your own in `/etc/rsyslog.d`, which keeps the rsyslog default
+format, nor to remote forwarding, which has `RSYSLOG_REMOTE_TEMPLATE` below.
+
+If you also wish to log `mail.*` messages to file on persistent volume, you can do something like:
 
 ```
 environment:


### PR DESCRIPTION
Two small independent commits, both closing something an earlier change left behind.

## Let dependabot update the pinned test dependencies

`dependabot.yml` opens with:

```
# tests/requirements.txt pins no versions, so a pip ecosystem would have
# nothing to bump and is left out.
```

That stopped being true when #186 pinned the file. The two changes landed close enough together that neither noticed the other, and the result is that the pinned test dependencies are now the one set of dependencies nothing keeps current — which is the failure mode pinning was meant to trade away, not one it was meant to create.

A `pip` ecosystem on `/tests` puts them back under the same treatment as the actions and the base image. Nothing else changes: a bump arrives as a pull request that runs the suite, which is the thing that actually knows whether a new testcontainers still works, and `dependabot-auto-merge.yml` applies on the same minor-and-patch terms as everything else.

Left alone deliberately: `axllent/mailpit:v1.27` in `tests/fixtures/mailpit.py` is still a moving minor tag, and the suite reads that REST API in a good number of places. Dependabot's docker ecosystem scans the Dockerfile, not a Python constant, so it cannot reach it. Pinning it exactly would make it deterministic but leave it with nothing to update it — worth a decision, which is why it is not made here.

## Say what RSYSLOG_TIMESTAMP does

The variable appears once in the README, inside an example that sets it to `yes`. Nowhere is it said what it controls, or that it defaults to `no`.

That was survivable while the default did nothing to the container log. It stopped being survivable in #154, when the default started working: the timestamp and the hostname left every line on stdout, a visible change for anyone whose log pipeline parses the message rather than docker's own metadata, and the README had nothing to point them at.

This says what each setting produces, that docker keeps a timestamp either way, and which destinations the variable does not reach — an `/etc/rsyslog.d` file of the user's own keeps the rsyslog default format, and remote forwarding has `RSYSLOG_REMOTE_TEMPLATE`.

## Verified

Neither file is read by the suite (`README.md` and `dependabot.yml` appear in tests only inside comments), so it was not re-run for this — the change cannot reach it. `dependabot.yml` parses as YAML and now declares three ecosystems: `github-actions` on `/`, `docker` on `/`, `pip` on `/tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESL6CyuHqmVYf3XaJW6Hxm