### PR TITLE
Wait for rsyslogd's own start line before reading the log

### DIFF
--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -4,7 +4,7 @@ import time
 
 from testcontainers.core.container import DockerContainer
 
-from tests.helpers import healthcheck_after_stopping
+from tests.helpers import container_log, healthcheck_after_stopping, wait_for_log
 
 HEALTHCHECK = "/root/healthcheck"
 SUBMISSION = "submission/inet=submission inet n - y - - smtpd"
@@ -243,9 +243,14 @@ def test_the_check_writes_nothing_to_the_log(relay_factory):
     them is what keeps a connect and a disconnect out of the log each time.
     """
     relay = relay_factory()
-    before = relay.get_logs()[0].decode()
+    # rsyslogd writes its own start line once it has finished starting, which
+    # is after "run" has started postfix and can be after the relay answers,
+    # the moment the factory calls it started. Snapshotting before that line
+    # lands leaves it to arrive during the loop below, where it reads as a
+    # line the health check wrote.
+    before = wait_for_log(relay, "rsyslogd:")
 
     for _ in range(5):
         assert run_healthcheck(relay, expected=0)[0] == 0
 
-    assert relay.get_logs()[0].decode() == before
+    assert container_log(relay) == before


### PR DESCRIPTION
Closes #228.

`test_the_check_writes_nothing_to_the_log` snapshots the container log, runs the health check five times and asserts nothing was added. It fails intermittently on a line the check did not write:

```
+ rsyslogd: [origin software="rsyslogd" swVersion="8.2504.0" x-pid="217" ...] start
```

`run` starts `rsyslogd -n &` before postfix, but rsyslogd writes that line once it has finished starting, and `run` writes to stdout directly while everything else goes through rsyslogd. So the line can land after postfix is already answering, which is the moment the fixture calls the relay started. When it lands after the snapshot instead of before, it arrives during the loop and reads as a line the health check wrote.

This takes the snapshot once that line is in the log, so what follows is only what the check does. It also reads the log through the `container_log` / `wait_for_log` helpers the rest of the suite uses, rather than `get_logs()` directly.

Matching on `rsyslogd:` rather than the whole banner keeps it working under either template: `RSYSLOG_TIMESTAMP` changes what precedes the syslog tag, not the tag itself.

Seen on #215, where the amd64 `Pytest` job failed and `Pytest (arm64)` passed on the same commit, on a change que touches nothing but a workflow file. Not reproducible on demand, so the evidence for the fix is the mechanism above rather than a red-to-green run; the race is narrowed to nothing by waiting for the line that was racing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8f8cYHQQkqat1cXsJgRFN