### PR TITLE
Point postfix at the trust store the image already ships

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,19 @@ RUN \
 # Try to use TLS when sending to other smtp servers.
 # No TLS for connecting clients, trust docker network to be safe
 # IPv4 only, because the packaged default is whatever the build machine had.
+# The trust store ca-certificates installs is named as the CA file, or postfix
+# has nothing to check a server certificate against and the two security levels
+# that authenticate the next hop, "verify" and "secure", cannot be used at all.
+# CAfile rather than CApath: the smtp client runs chrooted in the queue and
+# opens this while it is still root, before the chroot, which a directory of
+# hashed links would not survive.
 ENV \
   POSTFIX_myhostname=hostname \
   POSTFIX_mydestination=localhost \
   POSTFIX_mynetworks=0.0.0.0/0 \
   POSTFIX_inet_protocols=ipv4 \
   POSTFIX_smtp_tls_security_level=may \
+  POSTFIX_smtp_tls_CAfile=/etc/ssl/certs/ca-certificates.crt \
   POSTFIX_smtpd_tls_security_level=none \
   OPENDKIM_Socket=inet:12301@localhost \
   OPENDKIM_Mode=sv \

--- a/README.md
+++ b/README.md
@@ -375,6 +375,13 @@ offers it (`POSTFIX_smtp_tls_security_level=may`). Set it to `encrypt` when
 relaying through a provider, where an unencrypted connection is a
 misconfiguration rather than the only option.
 
+`encrypt` only means the connection was encrypted, not that it was the right
+server: it accepts any certificate. `verify` and `secure` also check the
+certificate against the trust store the image ships, which is what turns
+"nobody read this on the way" into "this went to the provider I meant".
+`POSTFIX_smtp_tls_CAfile` names that store and is set by default, so those two
+levels work without anything else being mounted.
+
 ### Client authentication
 The container includes [Postfix SASL](https://www.postfix.org/SASL_README.html) authentication options that are disabled by default.
 

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -10,8 +10,54 @@ These tests share the default relay, so they cost no extra container.
 
 import re
 
-from tests.helpers import (esmtp_features, listening_ports, postconf,
+import pytest
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+from tests.helpers import (esmtp_features, image_run, listening_ports, postconf,
                            process_running, send, wait_for_log)
+
+# A next hop whose certificate is signed by a CA of our own, so that trusting
+# it is a question about the trust store rather than about the certificate.
+TRUSTED_HOP = 'trusted-next-hop'
+CERTIFICATE_MATERIAL = f"""
+cd /tmp &&
+openssl req -x509 -newkey rsa:2048 -noenc -days 1 -subj /CN=test-ca \
+  -keyout ca-key.pem -out ca.pem 2> /dev/null &&
+openssl req -newkey rsa:2048 -noenc -subj /CN={TRUSTED_HOP} \
+  -addext subjectAltName=DNS:{TRUSTED_HOP} -keyout key.pem -out csr.pem 2> /dev/null &&
+openssl x509 -req -in csr.pem -CA ca.pem -CAkey ca-key.pem -days 1 \
+  -copy_extensions copy -out cert.pem 2> /dev/null &&
+cat ca.pem && echo === && cat cert.pem && echo === && cat key.pem
+"""
+
+
+@pytest.fixture
+def trusted_next_hop(postfix_image, mailpit_image, shared_network):
+    """A server offering STARTTLS with a certificate a given CA signed.
+
+    Returns that CA, for the relay to be given as its whole trust store: a
+    relay that verifies it has looked in the store, and one that does not has
+    nothing to look in.
+    """
+    ca, certificate, key = image_run(
+        postfix_image, ["sh", "-c", CERTIFICATE_MATERIAL]).split('===\n')
+
+    container = DockerContainer(mailpit_image) \
+        .with_network(shared_network) \
+        .with_network_aliases(TRUSTED_HOP) \
+        .with_env('MP_SMTP_TLS_CERT', '/cert.pem') \
+        .with_env('MP_SMTP_TLS_KEY', '/key.pem') \
+        .with_copy_into_container(certificate.encode(), '/cert.pem') \
+        .with_copy_into_container(key.encode(), '/key.pem')
+
+    container.start()
+    try:
+        wait_for_logs(container, ".*accessible via.*")
+        yield ca
+    finally:
+        container.stop()
 
 
 def test_the_banner_announces_myhostname(postfix):
@@ -158,3 +204,26 @@ def test_mail_for_any_domain_is_accepted(postfix, mailpit):
 
     assert sorted(to['Address'] for to in message['To']) == \
         ['someone@first.example', 'someone@second.example']
+
+
+def test_a_next_hop_the_trust_store_vouches_for_is_verified(trusted_next_hop,
+                                                            postfix_factory):
+    """"verify" is the level that authenticates the server being handed the
+    mail, and it needs something to check the certificate against.
+
+    The relay is given one CA as its whole trust store, and the next hop's
+    certificate is signed by it, so the delivery only goes through if postfix
+    read the file the image points it at. Without a CA file it defers every
+    message with "Server certificate not verified".
+    """
+    relay = postfix_factory(env={
+        'POSTFIX_relayhost': f"[{TRUSTED_HOP}]:1025",
+        'POSTFIX_smtp_tls_security_level': 'verify',
+        'POSTFIX_smtp_tls_loglevel': '1',
+    }, files={'/etc/ssl/certs/ca-certificates.crt': trusted_next_hop})
+
+    send(relay, subject='verified next hop')
+
+    log = wait_for_log(relay, 'status=sent')
+
+    assert f"Verified TLS connection established to {TRUSTED_HOP}" in log

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -26,6 +26,10 @@ DEFAULT_ENVIRONMENT = [
     # time from the IPv6 support of the machine doing the build.
     ('POSTFIX_inet_protocols', 'ipv4'),
     ('POSTFIX_smtp_tls_security_level', 'may'),
+    # The trust store ca-certificates puts in the image. Without it postfix
+    # has nothing to check a server certificate against, so the two levels
+    # that authenticate the next hop cannot be used at all.
+    ('POSTFIX_smtp_tls_CAfile', '/etc/ssl/certs/ca-certificates.crt'),
     ('POSTFIX_smtpd_tls_security_level', 'none'),
     # OpenDKIM: everything but the domains, which is what turns signing on.
     ('OPENDKIM_Socket', 'inet:12301@localhost'),
@@ -250,3 +254,15 @@ def test_the_image_is_a_single_debian_release(image_shell):
 
     assert exit_code == 0
     assert output.strip().startswith('13.'), output
+
+
+def test_the_trust_store_the_ca_file_names_is_in_the_image(postfix_image):
+    """The default above is only worth having if the file is there.
+
+    ca-certificates is installed for this and nothing else: opendkim's trust
+    anchor is the DNSSEC root key, not a CA bundle.
+    """
+    bundle = image_run(postfix_image, [
+        "sh", "-c", "wc -l < /etc/ssl/certs/ca-certificates.crt"])
+
+    assert int(bundle) > 100


### PR DESCRIPTION
Closes #230.

ca-certificates is installed and nothing uses it. Postfix has no CA file and no CA path:

    $ docker run --rm --entrypoint postconf mwader/postfix-relay \
        -h smtp_tls_CAfile smtp_tls_CApath
    (both empty)

so the two security levels that authenticate the server the mail is handed to, "verify" and "secure", cannot be used at all. Setting one of them today defers every message with "Server certificate not verified", and the log says why:

    certificate verification failed for [next hop]: untrusted issuer /CN=...

even when the certificate is signed by a CA in /etc/ssl/certs. The operator has to find out for themselves that an undocumented POSTFIX_smtp_tls_CAfile is what makes the level they chose work. That matters most in the README's own relayhost recipe, which hands a provider a username and a password.

The Dockerfile names the bundle ca-certificates installs. Nothing changes for the default "may", which does not verify anything, or for "encrypt", which only requires the connection to be encrypted -- what changes is that "verify" and "secure" now have something to verify against. CAfile rather than CApath: the smtp client is chrooted in the queue and opens this in its pre-jail initialisation, while it is still root, which a directory of hashed links would not survive.

Tested on the built image: a next hop offering STARTTLS with a certificate signed by a CA generated for the test, and the relay given that CA as its whole trust store. At "verify" the message is delivered and postfix logs "Verified TLS connection established"; on master the same test times out waiting for the delivery, with "untrusted issuer" in the log. The default is also pinned in the image tests, next to the other Dockerfile defaults, along with the bundle being present. The suite is 228 passed, 1 skipped.


Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ