### PR TITLE
Credit dependabot for the base image pin, not bump

### DIFF
--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -245,7 +245,7 @@ def test_the_package_lists_were_cleaned_up(image_shell):
 
 
 def test_the_image_is_a_single_debian_release(image_shell):
-    """The pinned base image, which "bump" keeps up to date."""
+    """The pinned base image, which dependabot keeps up to date."""
     exit_code, output = image_shell("cat /etc/debian_version")
 
     assert exit_code == 0


### PR DESCRIPTION
#168 retired `wader/bump`: the workflow, the `Bumpfile` and the `# bump:` directive on the Dockerfile all went, and `.github/dependabot.yml`'s `docker` ecosystem does that job now. The docstring on `test_the_image_is_a_single_debian_release` still names bump, so it describes a mechanism the repository no longer has.

This is the second of the five stale comments listed in #225. The other three are not about bump and are left alone; the first on that list, the `dependabot.yml` header claiming `tests/requirements.txt` pins nothing, is already fixed in #223.