### PR TITLE
Say what the SRS maps and the saslauthd socket actually do

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,8 +438,9 @@ changing any of them.
     recipient side is not symmetrical:
     `recipient_canonical_classes=envelope_recipient,header_recipient`, so
     recipient addresses in headers *are* rewritten, and have been since the
-    feature landed. The comment above the block claims envelope-only for both;
-    the code is what is described here.
+    feature landed: a bounce coming back to an SRS address carries it in its
+    `To:` as well as in its envelope, and decoding both is what makes it
+    deliverable. (issue #225, commit `bed3c5b`)
 
 15. **`echo -n > /etc/opendkim.conf` truncates the packaged config on every
     start**, and the loop that rebuilds it explicitly `continue`s past
@@ -573,13 +574,3 @@ changing any of them.
     and a date is not a semver minor or patch, so base-image PRs never match
     the auto-merge rule and always wait for review. A suite change
     (trixie → forky) is a deliberate edit, as it was before. (commit `5de83d0`)
-
-### Comments that are currently wrong
-
-Two comments in the tree contradict the code they describe. Do not take them
-as evidence when auditing, and fix them where you are already editing the file:
-
-- `tests/test_sasl.py` still describes the removed `dpkg-statoverride`
-  mechanism in a docstring (invariant 10); the assertion it guards is correct.
-- the comment above the SRS canonical maps in `run` claims envelope-only
-  rewriting on both sides (invariant 14).

--- a/run
+++ b/run
@@ -198,8 +198,12 @@ srsConfig()
     done
 
     # Point postfix at postsrsd, unless the user configured the maps
-    # themselves. Only envelope addresses are rewritten: rewriting the
-    # message headers would break the visible From/To.
+    # themselves. The sender side is envelope only, so the visible From is
+    # left alone -- rewriting it would change who the message says it is
+    # from. The recipient side also covers header recipients, so that an SRS
+    # address a bounce carries in its To is decoded back along with the
+    # envelope; anything that is not an SRS address is returned unchanged by
+    # postsrsd and left as it was.
     if [ -z "$POSTFIX_sender_canonical_maps" ] ; then
       postconf -e "sender_canonical_maps=tcp:127.0.0.1:${POSTSRSD_SRS_FORWARD_PORT:-10001}"
     fi

--- a/tests/test_sasl.py
+++ b/tests/test_sasl.py
@@ -248,8 +248,8 @@ def test_the_saslauthd_socket_is_restricted_to_the_sasl_group(authenticated_rela
 
     That is a password oracle with no rate limit, and the log lines it
     writes go to the auth facility, which the generated rsyslog
-    configuration keeps off stdout. "run" asks for root:sasl 710 through
-    dpkg-statoverride, and postfix is added to the group for it.
+    configuration keeps off stdout. "run" creates the directory root:sasl
+    710 with "install -d", and postfix is added to the group for it.
     """
     assert container_exec(
         authenticated_relay,


### PR DESCRIPTION
The last two of the five things #225 lists. The other three have landed since: the dependabot header in #223, the bump docstring in #232, and the README's table of test files in #219.

The comment above the SRS canonical maps says only envelope addresses are rewritten, and the block under it sets
recipient_canonical_classes=envelope_recipient,header_recipient. Header recipients are rewritten too, and deliberately: a bounce coming back to an SRS address carries it in its To as well as in its envelope, and decoding both is what makes it deliverable. What is envelope only is the sender side, which is the half that matters for the visible From. Checked against a running relay: sender_canonical_classes is envelope_sender, the reverse map turns SRS0=...=example.com=sender@srs.example.com back into sender@example.com, and an address that is not an SRS one is returned not-found and left alone.

The saslauthd socket docstring credits dpkg-statoverride for the mode of the directory. That was replaced in #179 by "install -d -o root -g sasl -m 710", because the override only records what a future dpkg unpack should apply -- which is nothing a container ever runs -- so the mode never reached the directory at all. The assertion is right; only the sentence explaining it was left behind.

Both are comments: nothing about the image changes. tests/test_sasl.py and tests/test_srs.py pass, 31 tests, which is where the two claims live.

Closes #225


Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ