### PR TITLE
Catch CLAUDE.md up with the two comments that were fixed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ why merge commits name someone else's namespace.
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment is also where the check names are recorded. |
-| `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image. No pip ecosystem. |
+| `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`. |
 
 There is no `CONTRIBUTING.md`, no linter config of any kind and no per-file
 license header — see [Conventions](#conventions).
@@ -576,14 +576,9 @@ changing any of them.
 
 ### Comments that are currently wrong
 
-Four comments in the tree contradict the code they describe. Do not take them
+Two comments in the tree contradict the code they describe. Do not take them
 as evidence when auditing, and fix them where you are already editing the file:
 
-- `.github/dependabot.yml` says `tests/requirements.txt` pins no versions and
-  leaves out a pip ecosystem for that reason — it pins all six, so the premise
-  for omitting the ecosystem no longer holds.
-- `tests/test_image.py` still credits "bump" with keeping the base pin current
-  (invariant 31).
 - `tests/test_sasl.py` still describes the removed `dpkg-statoverride`
   mechanism in a docstring (invariant 10); the assertion it guards is correct.
 - the comment above the SRS canonical maps in `run` claims envelope-only


### PR DESCRIPTION
CLAUDE.md landed in #224 with a list of four stale comments and a layout table written against the dependabot config of the time. Two of the four have since been fixed, and the config has grown an ecosystem:

- #223 added the `pip` ecosystem for `tests/requirements.txt` and removed the header comment saying the file pinned nothing.
- #232 pointed the `test_image.py` docstring at dependabot instead of bump.

So the file now overstates what is wrong and understates what Dependabot covers — which is the failure mode the list exists to prevent, since it tells a reader not to trust those comments and to fix them where they are already editing.

The other two entries were checked against `master` and still hold, so they stay: `tests/test_sasl.py` line 252 still describes `dpkg-statoverride`, and the comment above the SRS canonical maps in `run` still claims envelope-only rewriting while the code sets `recipient_canonical_classes=envelope_recipient,header_recipient`. Both are also still listed in #225.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8f8cYHQQkqat1cXsJgRFN