### PR TITLE
Pin the mailpit image to a version instead of a moving tag

### DIFF
--- a/tests/fixtures/mailpit.py
+++ b/tests/fixtures/mailpit.py
@@ -32,7 +32,7 @@ mailpit_module.wait_for_logs = functools.partial(
 from tests.conftest import print_log_on_failure
 from tests.helpers import once_across_workers, poll_until
 
-IMAGE = "axllent/mailpit:v1.27"
+IMAGE = "axllent/mailpit:v1.27.11"
 
 
 class Mailpit:


### PR DESCRIPTION
Closes #235

`axllent/mailpit:v1.27` is a *minor* tag: upstream re-points it at every patch release, and eleven have been published under it since it was chosen. So the server the whole suite reads its results back from can differ between two runs of the same commit.

That matters more here than a floating tag usually does. Mailpit is not a library the suite imports, it is the stand-in for the outside world, and the suite reads its REST API closely — six endpoints and eleven JSON field names, used sixty-nine times across the test files, `ReturnPath` alone asserted nineteen times. A release that renames one of those does not fail one test; it fails a swathe of the suite, on whatever pull request happens to run next, with a diff that has nothing to do with it.

## This changes nothing about what runs

`v1.27.11` is what `v1.27` resolves to today. Same digest:

```
v1.27     -> axllent/mailpit@sha256:e22dce5b36f93c77082e204a3942fb6b283b7896e057458400a4c88344c3df68
v1.27.11  -> axllent/mailpit@sha256:e22dce5b36f93c77082e204a3942fb6b283b7896e057458400a4c88344c3df68
```

The suite passes identically either way: **225 passed, 1 skipped** on the tag, and **225 passed, 1 skipped** on the pin.

## What it deliberately does not do

**It does not keep the constant current.** Nothing does — the line has been touched twice in the history of the repository, both times as a side effect of a change about something else. Dependabot cannot reach it either: its `docker` ecosystem reads Dockerfiles and its `docker-compose` ecosystem reads compose files, and this is a string in a Python module. That is the other half of the problem, it is a tooling choice rather than a one-line change, and it is filed as an issue instead of being decided here.

**It does not move to a current mailpit.** Mailpit is at `v1.31.0`, four minors on. Running the suite against it, everything else identical:

```
1 failed, 224 passed, 1 skipped
FAILED tests/test_smtp.py::test_a_quoted_local_part_is_relayed
```

The relay is not at fault — it hands the address over exactly as given, and its next hop refuses it:

```
postfix/smtp[223]: to=<"odd user"@example.com>, relay=mailpit[172.18.0.3]:1025,
  dsn=5.1.3, status=bounced (host mailpit said: 553 5.1.3 The address is not a
  valid RFC 5321 address (in reply to RCPT TO command))
```

Mailpit now rejects a quoted local part, which RFC 5321 allows. So moving off `v1.27` needs a decision about that test, or a report upstream — not just a newer number. Worth knowing deliberately rather than discovering it in the middle of an unrelated review, which is what the floating tag was setting up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESL6CyuHqmVYf3XaJW6Hxm