### PR TITLE
Drop the stale comment list now that it is empty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,8 +438,8 @@ changing any of them.
     recipient side is not symmetrical:
     `recipient_canonical_classes=envelope_recipient,header_recipient`, so
     recipient addresses in headers *are* rewritten, and have been since the
-    feature landed. The comment above the block claims envelope-only for both;
-    the code is what is described here.
+    feature landed: a bounce carries the SRS address in its `To` as well as in
+    its envelope, and decoding both is what makes it deliverable.
 
 15. **`echo -n > /etc/opendkim.conf` truncates the packaged config on every
     start**, and the loop that rebuilds it explicitly `continue`s past
@@ -573,13 +573,3 @@ changing any of them.
     and a date is not a semver minor or patch, so base-image PRs never match
     the auto-merge rule and always wait for review. A suite change
     (trixie → forky) is a deliberate edit, as it was before. (commit `5de83d0`)
-
-### Comments that are currently wrong
-
-Two comments in the tree contradict the code they describe. Do not take them
-as evidence when auditing, and fix them where you are already editing the file:
-
-- `tests/test_sasl.py` still describes the removed `dpkg-statoverride`
-  mechanism in a docstring (invariant 10); the assertion it guards is correct.
-- the comment above the SRS canonical maps in `run` claims envelope-only
-  rewriting on both sides (invariant 14).


### PR DESCRIPTION
**Merge this after #233.** It is the only ordering constraint: #233 fixes the last two comments the list names, and merging this first would claim the tree has no stale comments while those two are still there. There is no file overlap, so no conflict either way.

CLAUDE.md's *Comments that are currently wrong* list exists to stop a reader trusting a comment the code has outgrown. Between them, #223 (dependabot header), #232 (bump docstring), #219 (README test table) and #233 (SRS maps, saslauthd socket) fix all five entries #225 collected. Keeping the heading with two entries that now match the code does the opposite of what the section is for — it sends someone to "fix" something already correct.

Invariant 14 ended on the same claim, that the comment above the SRS canonical maps says envelope-only for both sides. That sentence goes too, replaced by the reason the recipient side covers header recipients: a bounce carries the SRS address in its `To` as well as in its envelope, and decoding both is what makes it deliverable. That is the part worth keeping, et it matches the explanation #233 writes into `run`.

Documentation only — no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8f8cYHQQkqat1cXsJgRFN