### PR TITLE
Pull the mailpit image only when it is not already here

### DIFF
--- a/tests/fixtures/mailpit.py
+++ b/tests/fixtures/mailpit.py
@@ -101,15 +101,33 @@ class Mailpit:
             time.sleep(0.5)
 
 
+def _pull_if_absent():
+    """Fetch the image, unless this machine already has it.
+
+    IMAGE names an exact version, so an image that is here is the image a
+    pull would bring: asking for it again is a registry round trip that buys
+    nothing and spends one of the hundred anonymous pulls Docker Hub allows
+    per six hours. Past that it answers 429, every mailpit fixture fails to
+    set up, and a hundred tests error out looking like a regression.
+
+    A runner starts without it and pulls exactly as before.
+    """
+    client = docker.from_env()
+
+    try:
+        client.images.get(IMAGE)
+    except docker.errors.ImageNotFound:
+        client.images.pull(IMAGE)
+
+
 @pytest.fixture(scope="session")
 def mailpit_image(tmp_path_factory):
-    """The mailpit image, pulled once for the whole run.
+    """The mailpit image, fetched once for the whole run.
 
     Starting a container pulls the image it needs, so without this every
     worker would pull this one at the same moment as the others.
     """
-    once_across_workers(tmp_path_factory, "mailpit-image",
-                        lambda: docker.from_env().images.pull(IMAGE))
+    once_across_workers(tmp_path_factory, "mailpit-image", _pull_if_absent)
 
     return IMAGE
 


### PR DESCRIPTION
`mailpit_image` pulls the image on every run. That was right while `IMAGE` was a moving tag, since the tag could point somewhere new. It is not right any more: `IMAGE` names an exact version now, so an image the machine already has is the image a pull would bring back, and asking again is a registry round trip that buys nothing.

It is not free, either. Docker Hub allows a hundred anonymous pulls per six hours per address, and past that it answers `429 Too Many Requests` instead of an image. Every mailpit fixture then fails to set up:

```
95 errors in 620.38s
ERROR tests/test_dkim.py::test_the_signature_covers_the_from_header
ERROR tests/test_dkim.py::test_a_domain_written_with_an_empty_selector_falls_back_to_mail
...
```

Which reads exactly like a regression until you look in the docker daemon's log and find:

```
Handler for POST /v1.54/images/create returned error: unknown: failed to
resolve reference "docker.io/axllent/mailpit:v1.27.11": unexpected status from
HEAD request to registry-1.docker.io: 429 Too Many Requests
```

That is where this came from — reached while running the suite repeatedly against three mailpit versions in an afternoon, which is more than a normal session, but the ceiling is shared by everything else on the same address and it is a confusing way to hit it.

## What changes

Only whether the pull happens. A runner starts with nothing and pulls exactly as before, so CI is unaffected; a machine that has run the suite once already skips it. The `once_across_workers` coordination is untouched, and so is the reason it exists — simultaneous pulls from several xdist workers being answered with a 429 is the same ceiling, reached a different way.

## Verified

Counting what the daemon actually did, with the image removed first:

| Call | Pulls recorded by the daemon |
| --- | --- |
| image absent | 1 |
| image present | 0 |

Full suite: 234 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESL6CyuHqmVYf3XaJW6Hxm