### PR TITLE
Expand the macros in inet_interfaces before greeting

### DIFF
--- a/run
+++ b/run
@@ -45,11 +45,14 @@ smtpdPort()
 # narrowed to addresses that do not include it, in which case the first one it
 # names does: a relay is free to serve only the address its clients reach it
 # on, and greeting loopback there would refuse to start a relay that works.
+# Read with "-x" so that main.cf macros are expanded: "inet_interfaces =
+# $myhostname" is an ordinary way to write this, and "-h" alone hands back the
+# literal "$myhostname" to dial.
 smtpdAddress()
 {
     local interfaces entry first
 
-    interfaces=$(postconf -h inet_interfaces)
+    interfaces=$(postconf -hx inet_interfaces)
     for entry in ${interfaces//,/ } ; do
       case "$entry" in
         all|loopback-only|127.0.0.1|localhost) echo 127.0.0.1 ; return ;;

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -330,6 +330,26 @@ def test_a_relay_that_does_not_serve_loopback_still_starts(postfix_factory, mail
     assert mailpit.wait_for_message('off loopback')
 
 
+def test_a_relay_that_names_its_interfaces_with_a_macro_still_starts(postfix_factory,
+                                                                     mailpit):
+    """inet_interfaces is often written "$myhostname" rather than spelled out.
+
+    postconf hands back what main.cf holds unless it is asked to expand, so
+    reading the setting without that gives the literal "$myhostname" to dial:
+    five refused connections and a container that exits 1 for a relay serving
+    every client it has.
+    """
+    relay = postfix_factory(env={'POSTFIX_myhostname': 'relay-by-macro',
+                                 'POSTFIX_inet_interfaces': '$myhostname'},
+                            kwargs={'hostname': 'relay-by-macro'})
+
+    assert exit_code_within(relay, seconds=20) is None
+
+    send(relay, subject='named by macro')
+
+    assert mailpit.wait_for_message('named by macro')
+
+
 def test_a_stop_during_start_up_is_not_reported_as_a_failure(postfix_factory):
     """SIGTERM before the relay is up is still a stop the operator asked for.
 


### PR DESCRIPTION
The start-up probe added in #217 reads the address to greet with `postconf -h inet_interfaces`. That flag returns what `main.cf` holds, not what it means.

`inet_interfaces = $myhostname` is an ordinary way to write that setting — it is how a relay serves one address without repeating the name — et `postconf -h` answers with the literal string `$myhostname`, which is then dialled as if it were a host.

Nothing resolves it, so all five attempts are refused and the container exits 1:

```
No smtpd survived a connection on $myhostname:25, which a setting postfix rejects
when smtpd reads it will do; refusing to relay. The line above starting "fatal:" names it.
```

There is no `fatal:` line above it, because postfix is fine. This is the same false refusal the address lookup was added to prevent, reached through the other spelling of the same configuration.

### The fix

`-x` is the flag that expands `main.cf` macros. The keywords the loop matches on carry none, so `all` and `loopback-only` behave exactly as before.

### Verified on the built image

| `inet_interfaces` | before | after |
| --- | --- | --- |
| unset (`all`) | starts | starts |
| a literal address | starts | starts |
| `loopback-only` | starts | starts |
| `$myhostname` | **exits 1** | starts, relays |

The new test in `tests/test_lifecycle.py` fails on master and passes here. Full suite: 235 passed, 1 skipped.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBcojydN8EwtDSr2cz1N1W
