### PR TITLE
Refuse a DKIM key that is there but cannot be read

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,16 @@ LABEL org.opencontainers.image.authors="Mattias Wadman <mattias.wadman@gmail.com
 # needs more than perl-base, so that dependency could correctly be narrowed and
 # take qshape down with it on a routine base bump. Naming it here costs nothing
 # now and keeps that from happening.
+# openssl is spelled out for the same reason: "run" uses it to refuse a DKIM
+# key it cannot read, and it is in the image today only because ca-certificates
+# depends on it.
 RUN \
   apt-get update && \
   apt-get -y --no-install-recommends install \
     procps \
     postfix \
     perl \
+    openssl \
     libsasl2-modules \
     libpam-pwdfile \
     sasl2-bin \

--- a/README.md
+++ b/README.md
@@ -497,7 +497,14 @@ specify a whitespace-separated list of domains in the environment variable
 "`<selector>`" using the syntax `OPENDKIM_DOMAINS=<domain>=<selector>`.
 
 At container start, RSA key pairs will be generated for each domain unless the
-file `/etc/opendkim/keys/<domain>/<selector>.private` exists. If you want the
+file `/etc/opendkim/keys/<domain>/<selector>.private` exists.
+
+Signing that was asked for and cannot happen stops the container rather than
+being skipped, so a relay never quietly sends unsigned mail on your behalf.
+It exits with a message on stderr if a key has to be generated and cannot be
+written — a read-only `/etc/opendkim/keys` is the usual reason — or if a key
+that is already there cannot be read as a private key, which is what an empty
+or truncated file looks like. If you want the
 keys to persist indefinitely, make sure to mount a volume for
 `/etc/opendkim/keys`, otherwise they will be destroyed when the container is
 removed.

--- a/run
+++ b/run
@@ -189,6 +189,25 @@ dkimConfig()
         fi
       fi
 
+      # A key that is there but cannot be read is the same failure arriving by
+      # another door, and the guard above never sees it: a <selector>.private
+      # that is empty, truncated or restored from a backup that was taken
+      # mid-write skips the generation entirely because the file exists. Then
+      # the tables below name it, opendkim starts having loaded nothing, and
+      # every message goes out unsigned while the container reports healthy --
+      # the signing that was asked for silently not happening, which is the
+      # thing the refusal above exists to prevent.
+      #
+      # "openssl pkey" rather than "openssl rsa": opendkim also takes ed25519
+      # keys, and the generic form parses both. It only has to answer whether
+      # this is a private key at all, which is what opendkim will fail on.
+      if ! openssl pkey -in "$privateFile" -noout > /dev/null 2>&1 ; then
+        echo "The DKIM private key for selector '$selector' in domain" \
+             "'$domain' cannot be read as a private key: $privateFile." \
+             "Refusing to relay without the signing that was asked for." >&2
+        exit 1
+      fi
+
       # Ensure strict permissions required by opendkim
       chown opendkim:opendkim "$domainDir" "$privateFile"
       chmod a=,u=rwx "$domainDir"

--- a/tests/test_dkim.py
+++ b/tests/test_dkim.py
@@ -428,3 +428,24 @@ def test_a_key_that_could_not_be_generated_stops_the_container(postfix_factory):
 
     assert exit_code_within(relay, seconds=20) == 1
     assert 'Could not generate a DKIM key' in container_stderr(relay)
+
+
+def test_a_key_that_cannot_be_read_stops_the_container(postfix_factory):
+    """A key that is there but unusable takes the other door.
+
+    An empty, truncated or half-restored <selector>.private exists, so the
+    generation above never runs and never looks at it. opendkim then starts
+    with nothing loaded and the relay goes on sending unsigned, healthy and
+    quiet, which is the outcome the refusal exists to prevent.
+    """
+    relay = postfix_factory(
+        env={'OPENDKIM_DOMAINS': 'example.com=sel1'},
+        files={'/etc/opendkim/keys/example.com/sel1.private': ""},
+        wait_ready=False)
+
+    # Generous rather than tight: the container does start up as far as the
+    # key before it refuses, and the suite runs four files at a time, so 20
+    # seconds was enough alone and not always enough under that load. It
+    # returns as soon as the container exits, so the bound costs nothing.
+    assert exit_code_within(relay, seconds=45) == 1
+    assert 'cannot be read as a private key' in container_stderr(relay)


### PR DESCRIPTION
The refusal added in #218 guards key *generation*, and generation only runs when the file is not there. A <selector>.private that exists but is unusable -- empty, truncated, restored from a backup taken mid-write, or left behind by a container killed inside opendkim-genkey on a mounted /etc/opendkim/keys -- takes the other door: the file exists, nothing generates it, nothing looks at it. The tables then name it, opendkim starts having loaded nothing, and the relay sends every message unsigned while docker reports it healthy.

That is the outcome #218 exists to prevent, reached by the path it does not cover, and it is the quieter of the two: measured on the built image with an empty sel1.private, the container comes up healthy, answers 250 to a message sent over SMTP, and relays it unsigned. The only hint is a "cat: ... .txt: No such file" line under the script's own "DNS records:" heading.

"openssl pkey -in ... -noout" is the check. Not "openssl rsa": opendkim also takes ed25519 keys and the generic form parses both, and the question here is only whether this is a private key at all, which is what opendkim will fail on. Verified in the image: it rejects an empty file and a key truncated to 200 bytes, and accepts what opendkim-genkey writes.

openssl is named in the Dockerfile with it. The package is already in the image and this adds nothing to it, but it arrives only as a dependency of ca-certificates -- exactly the situation perl and qshape are in, where a correct narrowing of somebody else's dependency would take this down on a routine base bump.

The README's DKIM section gains the behaviour: signing that was asked for and cannot happen stops the container, whether the key could not be written or cannot be read.

Tested on the built image: the new test fails on master (the container keeps running) and passes here. The suite is 235 passed, 1 skipped, twice in a row -- the bound in the new test is deliberately generous because 20 seconds was enough for it alone and not always enough with four files running at once.

Closes #248

Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ