### PR TITLE
Correct four things CLAUDE.md says about the tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ why merge commits name someone else's namespace.
 | `run` | The entrypoint. Resolves `<NAME>_FILE` secrets, turns `POSTFIX_*`, `POSTFIXMASTER_*`, `POSTMAP_*`, `OPENDKIM_*`, `POSTSRSD_*`, `RSYSLOG_*`, `SASL_Passwds` and `POSTMASTER_ADDRESS` into config, starts the daemons, asks postfix for an SMTP greeting, then runs a `pgrep`-polling supervision loop. Nearly all behaviour lives here. |
 | `healthcheck` | `pgrep`s `master`, checks a listening socket for every `inet` service in `postconf -M`, then `rsyslogd` always, `opendkim`/`postsrsd` whenever the environment *or the artefacts start-up left behind* say so, and `saslauthd` when `SASL_Passwds` is set. |
 | `pytest.ini` | `addopts = -n auto --dist loadfile --maxprocesses 4` and one registered marker, `smoke`. No `testpaths`, no `filterwarnings`, no `xfail_strict`. |
-| `.dockerignore` | Keeps `.git`, `README.md`, `LICENSE`, `tests` and `pytest.ini` out of the build context. |
+| `.dockerignore` | Keeps `.git`, `README.md`, `LICENSE`, `tests`, `pytest.ini`, `CLAUDE.md` and `.claude` out of the build context. |
+| `.claude/` | `settings.json` and `hooks/session-start.sh`, checked in. The hook is what makes a fresh web session able to run anything: it starts dockerd and installs `tests/requirements.txt`. Not in the build context — see `.dockerignore` above. |
 | `tests/__init__.py` | Empty; makes `tests` a package, which is what lets `conftest.py` name plugins as `tests.fixtures.*` and lets modules do `from tests.helpers import …`. pytest therefore has to be run from the repo root. There is no `tests/fixtures/__init__.py`. |
 | `tests/conftest.py` | Registers the four fixture modules as pytest plugins, and defines the failure plumbing: `print_log_on_failure`, an autouse `shared_container_logs` fixture, and a `pytest_runtest_makereport` wrapper hook that stashes the report on the item. |
 | `tests/helpers.py` | The shared vocabulary — `poll_until`, `once_across_workers`, `wait_for_smtp`, `send`, `container_exec`, `postconf`, `listening_ports`, `exit_code_within` and the rest. Imported by every test module but `test_sendmail.py`, and by three of the four fixture modules. `file_missing` is defined and never called. |
@@ -40,7 +41,7 @@ why merge commits name someone else's namespace.
 | `tests/fixtures/postfix.py` | Six fixtures: `postfix_image`, `postfix` and `_relay_pool` (session, the last being the per-configuration relay pool); `postfix_factory`, `postfix_shared` and `docker_volume` (function). Every relay gets `POSTFIX_relayhost=mailpit:1025`, set before the caller's env so a test can override it; readiness is an SMTP connection, not a log line. Reads `POSTFIX_RELAY_IMAGE` / `POSTFIX_RELAY_ARCH`. |
 | `tests/fixtures/mailpit.py` | The remote-SMTP stand-in, pinned at `axllent/mailpit:<tag>`: a `Mailpit` REST client class plus `mailpit_image` and `mailpit_container` (session), `mailpit` and `mailpit_factory` (function). Also rebinds the library's `wait_for_logs` to a `functools.partial` with a shorter poll interval. |
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
-| `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`. The README's per-file table covers all but `test_qshape.py` and `test_secrets.py`. |
+| `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`. All sixteen have a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
 | `.github/workflows/ci.yml` | `name: ci`. One job, `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
@@ -62,7 +63,8 @@ Dockerfile ──FROM──> debian:trixie-<date>-slim
     ├──COPY──> run          -> /root/run          <- CMD
     └──COPY──> healthcheck  -> /root/healthcheck  <- HEALTHCHECK
 
-.dockerignore excludes .git, README.md, LICENSE, tests, pytest.ini
+.dockerignore excludes .git, README.md, LICENSE, tests, pytest.ini,
+    CLAUDE.md, .claude
     => nothing under tests/, and not pytest.ini, can invalidate the build cache
 
 pytest.ini ──addopts──> pytest-xdist   (-n auto --dist loadfile --maxprocesses 4)
@@ -396,8 +398,10 @@ changing any of them.
    container re-runs the whole script over a filesystem that already has its
    results, which is also why `run` removes the four stale pid files near the
    top. Note that refusing to relay is now the normal response to a daemon that
-   will not start or has died: `run` exits 1 from six places, and the SRS stop
-   of invariant 3 is one of them, not the exception.
+   will not start or has died, so the refusals are many rather than one — the
+   SRS stop of invariant 3 is one of them and not the exception. There is no
+   count here on purpose: it moved twice in one afternoon and a stale one is
+   worse than none. `grep -n 'exit 1' run` is the list.
 
 9. **`run` ends in a `pgrep -x` polling loop, not a bare `wait`.** rsyslogd is
    the only daemon that is a child of the script, so the bare `wait` this


### PR DESCRIPTION
All four were true when they were written and are not now. A document whose whole claim is that you can trust it without re-deriving it earns nothing by being mostly right, so these are worth a commit of their own rather than waiting for someone to be editing nearby.

.dockerignore is enumerated twice, in the layout table and in the dependency graph, both times as a closed list of five entries. It has seven: the commit that added CLAUDE.md appended CLAUDE.md and .claude to it and did not come back to either list. The consequence is not academic -- the graph's next line reasons about what can invalidate the build cache from exactly that list.

The layout row for tests/test_*.py ends "The README's per-file table covers all but test_qshape.py and test_secrets.py". The README's table has a row for each of the sixteen modules; the two it was missing were added in #219. As written it sends anyone auditing README completeness looking for a gap that is closed.

Invariant 8 ends on "run exits 1 from six places". #218 made it seven. Rather than write eight, the count is gone: it changed twice in one afternoon, a stale count is worse than none, and "grep -n 'exit 1' run" is both shorter and always right. The claim it supports -- that refusing is now the normal response and the SRS stop is not the exception -- is untouched.

The layout table has a row for every checked-in file except .claude/, which is not inert: its session-start hook is what makes a fresh web session able to start dockerd and install the test dependencies at all. It gets a row.

Documentation only; nothing about the image or the suite changes.

Closes #242


Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ