### PR TITLE
Put the probe's redirection where it silences something

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,12 +382,14 @@ changing any of them.
    fine. `run` therefore asks for one 220 and refuses to hand over without it.
    Three things about it are load-bearing: it runs *after* rsyslogd is started,
    so postfix's own `fatal:` line naming the setting is in the container log
-   above the refusal; inside `awaitGreeting` the `2> /dev/null` is attached to
-   the command substitution and not to the `exec`, because `exec … 2> /dev/null`
-   has no command to apply to and would silence the script's own stderr for the
-   rest of the container's life; and `smtpdPort` deliberately skips an smtpd
-   bound to a single address, which may be there for something that does not
-   answer this container. `healthcheck` does the opposite and checks every
+   above the refusal; inside `awaitGreeting` the `2> /dev/null` is on a group
+   *inside* the command substitution, not on the `exec`, because
+   `exec … 2> /dev/null` has no command to apply to and would silence the
+   script's own stderr for the rest of the container's life — and not on the
+   substitution either, which is what `greeting=$( … ) 2> /dev/null` reads as
+   and is not, bash applying it to the assignment where it silences nothing;
+   and `smtpdPort` deliberately skips an smtpd bound to a single address, which
+   may be there for something that does not answer this container. `healthcheck` does the opposite and checks every
    `inet` service including address-bound ones — both resolve a named endpoint
    such as `submission` through `getent services`. (issue #206, commit `1d6d8d3`)
 

--- a/run
+++ b/run
@@ -70,22 +70,28 @@ awaitGreeting()
 
     for try in 1 2 3 4 5 ; do
       # The connection is opened inside a subshell, and the redirection that
-      # silences a refused one is on the substitution rather than on "exec":
-      # "exec ... 2> /dev/null" has no command to apply to, so it would send
-      # this script's own stderr to /dev/null for the rest of the container's
-      # life, taking every message below with it.
+      # silences a refused one is on a group *inside* the substitution. Not on
+      # "exec": "exec ... 2> /dev/null" has no command to apply to, so it would
+      # send this script's own stderr to /dev/null for the rest of the
+      # container's life, taking every message below with it. And not on the
+      # substitution, which is what "greeting=$( ... ) 2> /dev/null" reads as
+      # and is not -- bash applies that to the assignment, which writes
+      # nothing, so it silences nothing.
       greeting=$(
-        exec 3<>"/dev/tcp/$address/$port" || exit
-        # Short: master accepts at once when an smtpd can run, and holds the
-        # connection open with nothing behind it when one cannot -- it keeps
-        # the socket while it throttles the service it could not start. Five
-        # tries of this is the whole cost of refusing a broken relay.
-        read -t 2 -r line <&3
-        # QUIT rather than dropping the connection, so the one line this
-        # leaves in the log is a disconnect and not a lost connection.
-        printf 'QUIT\r\n' >&3
-        echo "$line"
-      ) 2> /dev/null
+        {
+          exec 3<>"/dev/tcp/$address/$port" || exit
+          # Short: master accepts at once when an smtpd can run, and holds
+          # the connection open with nothing behind it when one cannot -- it
+          # keeps the socket while it throttles the service it could not
+          # start. Five tries of this is the whole cost of refusing a broken
+          # relay.
+          read -t 2 -r line <&3
+          # QUIT rather than dropping the connection, so the one line this
+          # leaves in the log is a disconnect and not a lost connection.
+          printf 'QUIT\r\n' >&3
+          echo "$line"
+        } 2> /dev/null
+      )
 
       case "$greeting" in 220*) return 0 ;; esac
       sleep 0.2


### PR DESCRIPTION
"greeting=$( ... ) 2> /dev/null" reads as redirecting the substitution and does not: bash applies that redirection to the assignment, which writes nothing at all, so the stderr of the subshell goes straight to the container log. Every attempt that cannot connect therefore prints two lines of bash's own before the sentence that explains what actually happened -- ten of them across the five tries, offering the wrong explanation first, above a message written to be the right one.

Checked directly, outside this repository:

  bash -c 'x=$( exec 3<>/dev/tcp/127.0.0.1/9 || exit ) 2> /dev/null'
    -> bash: connect: Connection refused
       bash: line 1: /dev/tcp/127.0.0.1/9: Connection refused
  bash -c 'x=$( { exec 3<>/dev/tcp/127.0.0.1/9 || exit ; } 2> /dev/null )'
    -> silent

It goes on a group inside the substitution, which is the only place it works. Not on the "exec", for the reason the comment already gave: "exec ... 2> /dev/null" has no command to apply to and would send this script's own stderr to /dev/null for the life of the container.

CLAUDE.md's invariant 7 asserted the behaviour that was wrong -- it names this redirection as one of the three load-bearing things about the probe and said it was attached to the command substitution. It is now, and the invariant says what distinguishes that from the assignment, which is the whole of the mistake.

No test. The failure is only visible when the probe cannot connect, and after #243 the way to arrange that -- an inet_interfaces the container cannot dial -- is exactly what now works, so an assertion there would pass without exercising anything. That is the shape of the vacuous test #218 had to repair, and one is enough.

The suite is 235 passed, 1 skipped.

Closes #246


Claude-Session: https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ