### PR TITLE
Stop opendkim and postsrsd, which the init scripts never did

### DIFF
--- a/run
+++ b/run
@@ -326,9 +326,27 @@ stopDaemons()
     [ -n "$stopped" ] && return
     stopped=1
 
+    # postfix stops through its own script, which finds master by pid file.
+    # The other two init scripts cannot find anything: both identify the
+    # process with start-stop-daemon's --exec, which resolves /proc/<pid>/exe,
+    # and reading that link across a uid boundary needs CAP_SYS_PTRACE, which
+    # docker does not grant. So opendkim's script says "none killed" and
+    # postsrsd's, which passes --oknodo, reports a success it did not have --
+    # neither daemon is signalled at all, and the log says otherwise.
+    #
+    # Signalling them directly reaches postsrsd everywhere: the process that
+    # holds its pid stays root, and only its chrooted worker drops privileges.
+    # opendkim drops its own, so this reaches it under docker's default
+    # capabilities and not under the smaller set the README recommends, which
+    # leaves out CAP_KILL. Nothing can there -- see invariant 9 -- and what it
+    # then does is what the init script already left it doing: waiting for
+    # docker to kill the container. Both are silenced because both have a pid
+    # they may not signal there: postsrsd matches two, and the chrooted worker
+    # that dropped privileges is refused even though the root process holding
+    # it is signalled and takes the worker with it.
     service postfix stop
-    service opendkim stop
-    service postsrsd stop
+    pkill -x -TERM opendkim 2> /dev/null
+    pkill -x -TERM postsrsd 2> /dev/null
     pkill -TERM saslauthd
     pkill -TERM rsyslogd
     wait "$rsyslogPid" 2> /dev/null

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -9,7 +9,8 @@ import time
 
 import pytest
 
-from tests.helpers import container_exec, exit_code_within, send
+from tests.helpers import (container_exec, container_log, container_stderr,
+                           exit_code_within, send)
 
 # The set documented in the README, and the reason for each of them:
 # CHOWN and FOWNER for giving the queue to postfix and the DKIM keys to
@@ -62,9 +63,16 @@ def test_dropping_everything_stops_the_container(postfix_factory):
 def test_the_hardened_relay_stops_gracefully(hardened_relay):
     """Stopping is the operation most likely to miss a capability.
 
-    "stopDaemons" signals daemons that dropped to their own users and waits
-    for them, and the README says a graceful stop is one of the things the
-    set above was checked against.
+    "stopDaemons" stops postfix through its own script and signals the rest,
+    and the README says a graceful stop is one of the things the set above was
+    checked against. Not all of it can be signalled here: opendkim runs as its
+    own user and CAP_KILL is one of the capabilities this set drops, so it is
+    left for docker to take down with the container -- which is what it was
+    already left doing, because the init script could not find it either.
+
+    What the stop must not do is say anything untrue about that, or leave an
+    error behind on the way out. It used to do both: opendkim's script
+    reported "none killed" and postsrsd's reported a success it had not had.
     """
     wrapped = hardened_relay.get_wrapped_container()
 
@@ -75,3 +83,9 @@ def test_the_hardened_relay_stops_gracefully(hardened_relay):
     wrapped.reload()
     assert wrapped.attrs['State']['ExitCode'] == 0
     assert elapsed < 10, f"stopping took {elapsed:.1f}s, the SIGTERM trap did not run"
+
+    log = container_log(hardened_relay) + container_stderr(hardened_relay)
+
+    assert 'none killed' not in log
+    assert 'Stopping Postfix Sender Rewriting Scheme daemon' not in log
+    assert 'not permitted' not in log

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -372,7 +372,12 @@ def test_a_stop_during_start_up_is_not_reported_as_a_failure(postfix_factory):
         wait_ready=False)
     wrapped = relay.get_wrapped_container()
 
-    time.sleep(1)
+    # Waited for rather than slept through. "DNS records:" is printed before
+    # the first key is generated and start-up runs for several seconds after
+    # it, so the signal lands inside start-up because the log says start-up is
+    # running -- not because a second happened to be the right guess on the
+    # machine it was written on.
+    wait_for_log(relay, "DNS records:")
     wrapped.stop(timeout=30)
 
     assert exit_code_within(relay, seconds=30) == 0

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -330,6 +330,35 @@ def test_a_relay_that_does_not_serve_loopback_still_starts(postfix_factory, mail
     assert mailpit.wait_for_message('off loopback')
 
 
+def test_the_stop_path_does_not_claim_daemons_it_never_signalled(postfix_factory):
+    """Two of the three init scripts cannot find their daemon in a container.
+
+    opendkim's and postsrsd's both identify the process with
+    start-stop-daemon's --exec, which resolves /proc/<pid>/exe, and both
+    daemons have dropped to their own user by then: reading that link across a
+    uid boundary needs CAP_SYS_PTRACE, which docker does not grant by default
+    and the capability list in the README does not ask for. Neither daemon was
+    signalled at all -- opendkim's script said "none killed" and postsrsd's,
+    which passes --oknodo, reported success it had not had.
+
+    Those two lines are what the mistake looks like from outside, and their
+    absence is what this pins: a shutdown that says nothing about a daemon it
+    did not stop, because it stops it.
+    """
+    relay = postfix_factory(env={'OPENDKIM_DOMAINS': 'example.com',
+                                 'POSTSRSD_SRS_DOMAIN': 'srs.example.com'})
+
+    poll_until(lambda: process_running(relay, 'postsrsd'),
+               description="postsrsd to be running before the container is stopped")
+
+    relay.get_wrapped_container().stop(timeout=30)
+
+    log = container_log(relay) + container_stderr(relay)
+
+    assert 'none killed' not in log
+    assert 'Stopping Postfix Sender Rewriting Scheme daemon' not in log
+
+
 def test_a_stop_during_start_up_is_not_reported_as_a_failure(postfix_factory):
     """SIGTERM before the relay is up is still a stop the operator asked for.
 


### PR DESCRIPTION
Closes #253

`stopDaemons` calls three init scripts. Two of them signal nothing at all.

Both `opendkim` and `postsrsd` identify the process with `start-stop-daemon`'s `--exec`, which resolves `/proc/<pid>/exe`, and both daemons have dropped to their own user by then: reading that link across a uid boundary needs `PTRACE_MODE_READ`, so `CAP_SYS_PTRACE`, which docker does not grant. `start-stop-daemon` matches nothing and each script says so in its own way — opendkim's prints `No /usr/sbin/opendkim found running; none killed`, and postsrsd's, which passes `--oknodo`, prints its ordinary **success** line.

Measured on the built image: after `service opendkim stop`, opendkim is still pid 58; after `service postsrsd stop`, postsrsd is still pid 78. With `--cap-add SYS_PTRACE` the same calls do stop them, which is the whole of the difference. So neither daemon has been getting the `SIGTERM` the comment above `stopDaemons` promises to give it before rsyslogd goes, and the container log has been claiming postsrsd stopped when it did not.

Signalling them directly reaches postsrsd everywhere, because the process holding its pid stays root and only its chrooted worker drops privileges. opendkim drops its own, so this reaches it under docker's default capabilities and **not** under the set the README recommends, which leaves out `CAP_KILL`: there nothing can — which is what invariant 9 already says about this script — and what opendkim then does is what the init script had left it doing anyway, waiting for docker to take the container down. Both pkills are silenced because both have a pid they may not signal in that configuration, postsrsd included: it matches two, and the worker is refused even though killing the root process takes it along.

Two tests, one per configuration, and both fail on master. The lifecycle one stops an ordinary relay; the capabilities one is the existing `test_the_hardened_relay_stops_gracefully`, whose docstring said `stopDaemons` "signals daemons that dropped to their own users and waits for them" — it could not, and it now says what is true and asserts the stop leaves behind neither a false claim nor an `Operation not permitted`.

**Second commit, same area.** `test_a_stop_during_start_up_is_not_reported_as_a_failure` used a bare `time.sleep(1)`, the only one in the suite outside the poll helpers. Measured with the eight domains it asks for: `DNS records:` at 0.36s, the last key at 0.8s, the relay not ready until 5.3s — so the second lands inside start-up here, with about 0.2s of margin on one side, and if start-up ever finished inside it the assertions would still pass while covering nothing. It waits for `DNS records:` instead, which is printed before the first key and followed by several seconds of start-up.

**Verified on the built image** in both capability sets: exit 0, and none of the three lines. `shellcheck -S error` passes. The suite is 236 passed, 1 skipped, and it merges cleanly onto master as it stands after #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BgFJrHxTFiQZ7XsnFjbcQ