### PR TITLE
Say what the recipient side of SRS actually does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,9 +474,15 @@ changing any of them.
     would rewrite the visible `From:`, which is not what SRS is for. The
     recipient side is not symmetrical:
     `recipient_canonical_classes=envelope_recipient,header_recipient`, so
-    recipient addresses in headers *are* rewritten, and have been since the
-    feature landed: a bounce carries the SRS address in its `To` as well as in
-    its envelope, and decoding both is what makes it deliverable.
+    that second class buys less than it reads as. Postfix rewrites headers
+    only for clients matching `local_header_rewrite_clients`, which defaults
+    to `permit_inet_interfaces` — the container's own addresses — and the
+    containers this relays for reach it over the docker network. Measured on
+    the built image, same message both ways: from the network the `To:` keeps
+    the SRS address, from loopback it is decoded. The envelope is decoded
+    either way, and it is the envelope that makes a bounce deliverable, so
+    nothing was ever wrong with the behaviour — only with the sentence that
+    described it.
 
 15. **`echo -n > /etc/opendkim.conf` truncates the packaged config on every
     start**, and the loop that rebuilds it explicitly `continue`s past

--- a/run
+++ b/run
@@ -262,10 +262,16 @@ srsConfig()
     # Point postfix at postsrsd, unless the user configured the maps
     # themselves. The sender side is envelope only, so the visible From is
     # left alone -- rewriting it would change who the message says it is
-    # from. The recipient side also covers header recipients, so that an SRS
-    # address a bounce carries in its To is decoded back along with the
-    # envelope; anything that is not an SRS address is returned unchanged by
-    # postsrsd and left as it was.
+    # from.
+    #
+    # The recipient side names header_recipient as well, which buys less than
+    # it reads as: postfix rewrites headers only for clients matching
+    # local_header_rewrite_clients, and that defaults to this container's own
+    # addresses. Mail from the containers this relays for arrives over the
+    # docker network instead, so it keeps the SRS address in its To and only
+    # its envelope is decoded -- which is the half that makes a bounce
+    # deliverable, so the behaviour is right either way. Anything that is not
+    # an SRS address postsrsd returns unchanged, and it is left as it was.
     if [ -z "$POSTFIX_sender_canonical_maps" ] ; then
       postconf -e "sender_canonical_maps=tcp:127.0.0.1:${POSTSRSD_SRS_FORWARD_PORT:-10001}"
     fi

--- a/tests/test_srs.py
+++ b/tests/test_srs.py
@@ -157,6 +157,14 @@ def test_a_bounce_to_a_rewritten_address_finds_the_original_sender(shared_srs_re
     message = mailpit.wait_for_message('the bounce')
 
     assert [to['Address'] for to in message['Bcc']] == ['sender@example.com']
+    # The envelope is what was decoded, and only the envelope. The To: header
+    # still carries the SRS address: recipient_canonical_classes names
+    # header_recipient, but postfix rewrites headers only for clients matching
+    # local_header_rewrite_clients, which defaults to this container's own
+    # addresses -- and a relay's clients reach it over the network. That is
+    # also why mailpit reports the decoded recipient as a Bcc above: it
+    # matches no address in the headers.
+    assert [to['Address'] for to in message['To']] == [rewritten]
 
 
 def test_postsrsd_is_only_reachable_from_the_container(shared_srs_relay):


### PR DESCRIPTION
Closes #255

The comment above the canonical maps, and invariant 14 in CLAUDE.md after it, say that because recipient_canonical_classes names header_recipient, "an SRS address a bounce carries in its To is decoded back along with the envelope". That is not what happens for the mail this image exists to relay.

Postfix applies header rewriting only to clients matching local_header_rewrite_clients, which defaults to permit_inet_interfaces -- the container's own addresses. The containers a relay serves reach it over the docker network, so their headers are left alone.

Measured on the built image, the same message sent both ways to an SRS address this relay had signed:

  from the docker gateway   To: SRS0=BHmD=G2=example.com=sender@srs.example.com
  from 127.0.0.1            To: sender@example.com

The envelope is decoded in both, which the relay log shows as "to=<sender@example.com>, orig_to=<SRS0=...>", and it is the envelope that makes a bounce deliverable. So the behaviour was never wrong, and this changes none of it: what was wrong is a sentence stating unconditionally something that holds only for mail the relay itself originates -- in a comment, and then in the document whose purpose is to be trusted without re-deriving it. I wrote both, in #233 and by way of #237.

The test that already covers this half is where it gets pinned. test_a_bounce_to_a_rewritten_address_finds_the_original_sender has been demonstrating it all along without saying so: it asserts the decoded recipient arrives in mailpit's Bcc, which is where mailpit puts an envelope recipient that matches no header address -- it did not match because the To: was never decoded. It now asserts the To: as well, so the test says what it shows.

That assertion passes on master: this pins behaviour that was mis-described rather than broken, so there is nothing here that fails before the change.

The suite is 237 passed, 1 skipped.