### PR TITLE
Rewrap the greeting-probe invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,9 +389,10 @@ changing any of them.
    substitution either, which is what `greeting=$( … ) 2> /dev/null` reads as
    and is not, bash applying it to the assignment where it silences nothing;
    and `smtpdPort` deliberately skips an smtpd bound to a single address, which
-   may be there for something that does not answer this container. `healthcheck` does the opposite and checks every
-   `inet` service including address-bound ones — both resolve a named endpoint
-   such as `submission` through `getent services`. (issue #206, commit `1d6d8d3`)
+   may be there for something that does not answer this container. `healthcheck`
+   does the opposite and checks every `inet` service including address-bound
+   ones — both resolve a named endpoint such as `submission` through
+   `getent services`. (issue #206, commit `1d6d8d3`)
 
 8. **`run` has no `set -e`, and that is still load-bearing** — but not for the
    reason it once was. `dpkg-statoverride` is gone (see 10). What would break


### PR DESCRIPTION
Invariant 7 was rewritten when the redirection moved onto a group inside the command substitution, and the sentence that followed was left joined to it:

```
   may be there for something that does not answer this container. `healthcheck` does the opposite and checks every
```

115 characters, where the longest other prose line in the file is 84.

Whitespace only — no wording changes, no behaviour, nothing else touched. After it, no prose line in the file exceeds 84.

Entirely cosmetic: nothing enforces a width here and nothing reads it wrong. Close it without ceremony if you would rather not carry the noise.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBcojydN8EwtDSr2cz1N1W
