### PR TITLE
Release the build lock when the build fails

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -56,7 +56,17 @@ def once_across_workers(tmp_path_factory, name, produce, timeout=600):
                    description=f"{name} to be made ready by another worker")
         return
 
-    produce()
+    # The lock is released if the work fails, so that a waiting worker takes it
+    # and reports its own error rather than polling for a marker that is never
+    # coming: the alternative is every other worker timing out on "to be made
+    # ready by another worker", which names neither the failure nor who hit it,
+    # and the run taking the whole timeout to say a build broke.
+    try:
+        produce()
+    except BaseException:
+        lock.unlink(missing_ok=True)
+        raise
+
     # Written only once the work is finished, so that a worker seeing it can
     # rely on the image being there.
     done.touch()


### PR DESCRIPTION
Closes #259

`once_across_workers` elects one xdist worker to build or pull an image while the others wait on a marker it writes when it is done. Nothing released the lock if the work raised: the marker never arrived, and every other worker polled for the full timeout before failing with

```
timed out after 600s waiting for <name> to be made ready by another worker
```

which names neither the error nor the worker that hit it. The real failure sat in one worker's output, ten minutes earlier. On CI the pytest step's `timeout-minutes: 10` fires at about the same moment, so the job is cancelled and the upload step is skipped — losing the junit output that would have named the cause.

Reachable whenever a build breaks: a `Dockerfile` that will not build, a base image that will not pull, a 429 that outlasts the retry. Which is exactly when a fast, accurate failure is worth most.

### The change

Releasing the lock hands the election to the next worker, which either does the work or fails with its own real error. `BaseException` rather than `Exception`, so a `KeyboardInterrupt` or a timeout inside `produce()` does not strand the others either.

### Verified

Called `once_across_workers` directly with `PYTEST_XDIST_WORKER` set and a `produce()` that raises:

| | before | after |
| --- | --- | --- |
| first worker | raises `RuntimeError` | raises `RuntimeError` |
| lock left behind | **yes** | no |
| next worker | times out on the marker | takes the lock and completes |

Full suite: 237 passed, 1 skipped.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBcojydN8EwtDSr2cz1N1W
