### PR TITLE
Record why the build lock is released on failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -625,7 +625,12 @@ changing any of them.
     429 rather than with the image. The first worker to create the lock does
     the work and touches a `.done` marker only after finishing; the rest wait
     on that marker. With no xdist worker in the environment it calls straight
-    through.
+    through. The `try`/`except BaseException` around the work is not defensive
+    padding: it removes the lock so a waiting worker takes it and reports its
+    own error, where leaving it makes every other worker poll the marker for
+    the full timeout and then blame "another worker" for a failure it cannot
+    name. `BaseException` and not `Exception`, so an interrupt or a timeout in
+    the work does not strand them either.
 
 30. **`POSTFIX_RELAY_IMAGE` is refused for an architecture the local daemon
     could build**, and `POSTFIX_RELAY_ARCH`, when set, must match what docker


### PR DESCRIPTION
Invariant 29 describes `once_across_workers`' election and its `.done` marker, but stops before the failure path — which was added when the lock stopped being left behind.

```python
try:
    produce()
except BaseException:
    lock.unlink(missing_ok=True)
    raise
```

A `try`/`except BaseException` around a single call reads like defensive padding, and it is the first thing a reader tidies away. Removing it restores a ten-minute hang: every worker but the one that failed polls a marker that is never coming, then fails with

```
timed out after 600s waiting for <name> to be made ready by another worker
```

blaming "another worker" for an error it cannot name, while the real failure sits in one worker's output ten minutes earlier.

`BaseException` rather than `Exception` est part of it too: a `KeyboardInterrupt`, or a timeout raised inside the work, would otherwise strand the others exactly as an ordinary exception did.

Documentation only, no behaviour change. This records something the change that introduced it did not — my own omission from that pull request.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBcojydN8EwtDSr2cz1N1W
