### PR TITLE
Finish the docs rule this file already states for the README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,13 @@ Notes a contributor will hit:
   current instances, and `xfail_strict` is not set in `pytest.ini`, so
   `strict=True` has to be written on each marker.
 - **Docs.** User-visible behaviour goes in `README.md`. If a change makes the
-  README wrong, the change is not finished.
+  README wrong, the change is not finished. The same holds for this file, and
+  it is the half that gets forgotten: it describes the tree, so a change to
+  `run`, `healthcheck`, the workflows or the fixtures can leave it wrong
+  without touching it. Before pushing one, grep this file for what you moved —
+  a count, a line number, an enumeration, a claim about what a script does.
+  Counts and line numbers are the first to rot, and are better replaced by
+  what they were being used to say than refreshed.
 
 ## Non-obvious invariants
 


### PR DESCRIPTION
The **Docs** convention says a change that leaves `README.md` wrong is not finished. Nothing says the same about `CLAUDE.md`, and that is the half that gets forgotten: it describes the *tree* rather than the product, so a change to `run`, `healthcheck`, the workflows or the fixtures can leave it wrong without touching it — and the author has no reason to look.

### Why it is worth a rule

Since this file landed it has needed correcting **eight times**, four of them commits that do nothing else:

| | |
| --- | --- |
| an `exit 1` tally | moved twice |
| the shellcheck listing | every line number had shifted |
| a pair of `pkill`s | became four |
| "the only two shell scripts" | became three |
| `test_image.py` "only `docker inspect`s" | it starts containers |
| the `.dockerignore` enumeration | was short from the day it was written |

Several of those were made wrong by the same author on the same day, in the change that caused them.

### What the rule says

It names what to check rather than asking for diligence in general — grep for the count, the line number, the enumeration, the claim about what a script does — and it says what to do with a number rather than refreshing it: replace it with what it was being used to say. A count that has rotted once will rot again.

Documentation only, no behaviour change. This is a judgement call about how the project wants to work rather than a defect, so it is entirely reasonable to close it.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBcojydN8EwtDSr2cz1N1W
