### PR TITLE
Keep the mailpit image current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,20 @@ updates:
     directory: /tests
     schedule:
       interval: weekly
+
+  # The mailpit image, which is the server every relayed message is read back
+  # from. It lives in a string in tests/fixtures/mailpit.py, and no ecosystem
+  # reads Python, so tests/mailpit.Dockerfile names it where this one looks --
+  # dependabot's docker file fetcher matches any file whose name contains
+  # "dockerfile" -- and the fixture reads the tag back out of that file.
+  #
+  # Unlike the base image above, a bump here is an ordinary semver minor or
+  # patch, so the auto-merge rule applies to it. That is the right way round:
+  # this is the test peer rather than the shipped image, every one of these
+  # pull requests runs the whole suite against the new mailpit, and the suite
+  # is the only thing that can say whether it still answers as the tests
+  # expect. One that does not stays red and waits for a person.
+  - package-ecosystem: docker
+    directory: /tests
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,7 +51,10 @@ updates:
   # from. It lives in a string in tests/fixtures/mailpit.py, and no ecosystem
   # reads Python, so tests/mailpit.Dockerfile names it where this one looks --
   # dependabot's docker file fetcher matches any file whose name contains
-  # "dockerfile" -- and the fixture reads the tag back out of that file.
+  # "dockerfile" -- and the fixture reads the tag back out of that file. The
+  # directory has to be named: the fetcher lists the one it is given and does
+  # not recurse, so the base image entry on "/" neither sees this file nor is
+  # disturbed by it.
   #
   # Unlike the base image above, a bump here is an ordinary semver minor or
   # patch, so the auto-merge rule applies to it. That is the right way round:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ why merge commits name someone else's namespace.
 | `tests/requirements.txt` | Six pinned packages: `dkimpy`, `docker`, `pytest`, `pytest-xdist`, `requests`, `testcontainers[mailpit]`. `dkimpy` is what satisfies `import dkim`, so grepping module names against this file looks like a miss when it is not. |
 | `tests/fixtures/shared_network.py` | Session-scoped `shared_network`: a testcontainers `Network()` with a generated, labelled name — not a fixed one, so an interrupted run leaves nothing for the next one to collide with. |
 | `tests/fixtures/postfix.py` | Six fixtures: `postfix_image`, `postfix` and `_relay_pool` (session, the last being the per-configuration relay pool); `postfix_factory`, `postfix_shared` and `docker_volume` (function). Every relay gets `POSTFIX_relayhost=mailpit:1025`, set before the caller's env so a test can override it; readiness is an SMTP connection, not a log line. Reads `POSTFIX_RELAY_IMAGE` / `POSTFIX_RELAY_ARCH`. |
-| `tests/fixtures/mailpit.py` | The remote-SMTP stand-in, pinned at `axllent/mailpit:<tag>`: a `Mailpit` REST client class plus `mailpit_image` and `mailpit_container` (session), `mailpit` and `mailpit_factory` (function). Also rebinds the library's `wait_for_logs` to a `functools.partial` with a shorter poll interval. |
+| `tests/mailpit.Dockerfile` | Not built and no part of any image. One `FROM axllent/mailpit:<tag>` line, so that Dependabot's docker ecosystem — whose file fetcher matches any name containing `dockerfile` — can offer a bump to the test peer. `tests/fixtures/mailpit.py` reads the tag back out of it. |
+| `tests/fixtures/mailpit.py` | The remote-SMTP stand-in, whose image is read from `tests/mailpit.Dockerfile` rather than written here: a `Mailpit` REST client class plus `mailpit_image` and `mailpit_container` (session), `mailpit` and `mailpit_factory` (function). Also rebinds the library's `wait_for_logs` to a `functools.partial` with a shorter poll interval. |
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
 | `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
@@ -49,7 +50,7 @@ why merge commits name someone else's namespace.
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
 | `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment is also where the check names are recorded. |
-| `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`. |
+| `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`, `docker` weekly on `/tests` for the mailpit anchor. |
 
 There is no `CONTRIBUTING.md`, no linter *config* of any kind — `lint.yml`
 passes its one flag on the command line — and no per-file license header — see
@@ -91,6 +92,9 @@ tests/test_*.py
 
          mailpit (function) ──> mailpit_container (session) ──> mailpit_image (session)
          mailpit_factory (function) ──────────────────────────────┘
+                                                                    │
+                                          tests/mailpit.Dockerfile ─┘
+                                          (the tag, where dependabot can see it)
 
          docker_volume (function)   -- takes no fixtures; creates and removes
                                        a docker volume and nothing else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -659,3 +659,19 @@ changing any of them.
     and a date is not a semver minor or patch, so base-image PRs never match
     the auto-merge rule and always wait for review. A suite change
     (trixie → forky) is a deliberate edit, as it was before. (commit `5de83d0`)
+
+32. **`tests/mailpit.Dockerfile` is never built, and both halves of it are
+    load-bearing.** It exists because Dependabot cannot read a version out of a
+    Python module, and the mailpit image is the one dependency most worth
+    keeping current: the suite reads every relayed message back from it. The
+    *name* is what makes it visible — the docker file fetcher selects on
+    `/dockerfile|containerfile/i`, an unanchored match on the base name, so
+    anything containing "dockerfile" is picked up and nothing else is. The
+    *directory* is why `.github/dependabot.yml` has a second `docker` entry on
+    `/tests`: `repo_contents` lists the configured directory and does not
+    recurse, so the base-image entry on `/` neither sees this file nor is
+    disturbed by it. And `tests/fixtures/mailpit.py` reads the tag back out
+    rather than repeating it, raising when the file is missing or has no
+    `FROM` line: a fallback to a version written in the module would work
+    perfectly and restore exactly the invisible constant this replaces.
+    (issue #235)

--- a/README.md
+++ b/README.md
@@ -742,6 +742,10 @@ docker exec <container> postqueue -j | jq -r '.recipients[].delay_reason' | sort
 This project uses [testcontainers](https://testcontainers.com/) with [pytest](https://docs.pytest.org/) for integration testing.
 
 [Mailpit](https://mailpit.axllent.org/) is also used to simulate a remote SMTP server.
+Its version is pinned in `tests/mailpit.Dockerfile`, which is where to change it:
+that file is never built, it exists so that Dependabot can offer a bump to a
+version the tests otherwise name only in Python, and `tests/fixtures/mailpit.py`
+reads the tag back out of it.
 
 ```bash
 # Create and enable python virtual environment

--- a/tests/fixtures/mailpit.py
+++ b/tests/fixtures/mailpit.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import time
 
 import docker
@@ -32,7 +33,31 @@ mailpit_module.wait_for_logs = functools.partial(
 from tests.conftest import print_log_on_failure
 from tests.helpers import once_across_workers, poll_until
 
-IMAGE = "axllent/mailpit:v1.27.11"
+def _pinned_image():
+    """The image tag, read from the file a version bot can see.
+
+    The suite reads every relayed message back from mailpit, so a release that
+    renames a JSON field fails a swathe of it at once -- which makes this the
+    dependency most worth keeping current, and the one no ecosystem could see
+    while it was a string in this module. tests/mailpit.Dockerfile names it
+    where Dependabot looks; this reads it back, so the two cannot drift and a
+    bump is one line in one file.
+
+    A missing or unparseable anchor raises. Falling back to a version written
+    here would restore exactly what this replaces: a constant that works and
+    that nothing updates.
+    """
+    anchor = os.path.join(os.path.dirname(__file__), os.pardir, 'mailpit.Dockerfile')
+
+    with open(anchor, encoding='utf-8') as lines:
+        for line in lines:
+            if line.startswith('FROM '):
+                return line[len('FROM '):].strip()
+
+    raise RuntimeError(f"no FROM line to read the mailpit image from in {anchor}")
+
+
+IMAGE = _pinned_image()
 
 
 class Mailpit:

--- a/tests/mailpit.Dockerfile
+++ b/tests/mailpit.Dockerfile
@@ -1,0 +1,12 @@
+# Not built, and no part of any image. This file exists so that the version of
+# the mailpit image can be seen by a bot that only understands Dockerfiles:
+# Dependabot's docker ecosystem matches any file whose name contains
+# "dockerfile", and .github/dependabot.yml points one at this directory.
+#
+# tests/fixtures/mailpit.py reads the tag back out of the line below, so this
+# is the one place the version is written and there is nothing to keep in step
+# by hand. Changing it here changes what the suite tests against.
+#
+# tests/ is excluded by .dockerignore, so this never reaches the build context
+# of the image itself.
+FROM axllent/mailpit:v1.27.11

--- a/tests/mailpit.Dockerfile
+++ b/tests/mailpit.Dockerfile
@@ -9,4 +9,4 @@
 #
 # tests/ is excluded by .dockerignore, so this never reaches the build context
 # of the image itself.
-FROM axllent/mailpit:v1.27.11
+FROM axllent/mailpit:v1.31.0

--- a/tests/mailpit.Dockerfile
+++ b/tests/mailpit.Dockerfile
@@ -1,7 +1,9 @@
 # Not built, and no part of any image. This file exists so that the version of
 # the mailpit image can be seen by a bot that only understands Dockerfiles:
 # Dependabot's docker ecosystem matches any file whose name contains
-# "dockerfile", and .github/dependabot.yml points one at this directory.
+# "dockerfile", and .github/dependabot.yml points one at this directory --
+# which it has to, because that fetcher lists the directory it is given and
+# does not recurse into others.
 #
 # tests/fixtures/mailpit.py reads the tag back out of the line below, so this
 # is the one place the version is written and there is nothing to keep in step

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -34,16 +34,6 @@ def logged_message_id(container, recipient):
     return re.search(rf'{queue_id}: message-id=(\S+)', log).group(1)
 
 
-def raw_headers(mailpit, message):
-    """The header block as it arrived.
-
-    Read from the stored message rather than from the parsed one: mailpit
-    fills in a Message-ID of its own when a message has none, so its JSON
-    cannot answer whether the relay added one.
-    """
-    return mailpit.raw(message['ID']).split(b'\r\n\r\n', 1)[0].decode()
-
-
 def test_helo_is_accepted_as_well_as_ehlo(postfix, mailpit):
     """A client that speaks plain SMTP has to be able to relay too."""
     smtp = smtplib.SMTP(postfix.get_container_host_ip(),
@@ -279,14 +269,25 @@ def test_an_unqualified_address_is_qualified_with_the_relay_name(postfix, mailpi
 
 
 def test_a_quoted_local_part_is_relayed(postfix, mailpit):
-    """Legal, rare, and the kind of address that gets mangled on the way."""
+    """Legal, rare, and the kind of address that gets mangled on the way.
+
+    RFC 5321 4.1.2 defines a local part as a Dot-string *or* a Quoted-string,
+    so the quotes are part of the address and a relay that drops them changes
+    who the message is for.
+
+    Read from what the relay handed to the next hop rather than from what the
+    next hop did with it. Those are different questions, and only the first is
+    this image's: mailpit answers "553 5.1.3 The address is not a valid RFC
+    5321 address" to this recipient from v1.28.3 on, so asserting on the
+    stored message made the test a test of the peer, and pinned the suite to
+    a mailpit older than that. The peer is still asked for, so that this is a
+    real delivery attempt to a server that is there rather than a deferral.
+    """
     send(postfix, recipients=('"odd user"@example.com',), subject='quoted local part')
 
-    message = mailpit.wait_for_message('quoted local part')
+    handed_over = wait_for_log(postfix, 'to=<"odd user"@example.com>')
 
-    # Read from the stored message: the quotes are part of the address and
-    # a parser that drops them changes who the message is for.
-    assert '"odd user"@example.com' in raw_headers(mailpit, message)
+    assert 'to=<"odd user"@example.com>' in handed_over
 
 
 def test_an_address_with_a_plus_is_relayed_untouched(postfix, mailpit):


### PR DESCRIPTION
Closes #235

The mailpit image is the server the whole suite reads every relayed message back from — six REST endpoints, ~11 JSON field names asserted ~69 times. It was also the one dependency nothing could update: a string in a Python module, which no Dependabot ecosystem reads. `wader/bump` could have (regex in any file); it was removed in favour of Dependabot and this capability went with it.

**The pin was not four minors behind by oversight — it was held there.** Measured release by release: v1.28.0/.1/.2 pass, **everything from v1.28.3 on fails**, and always the same single test. `test_a_quoted_local_part_is_relayed` read its assertion out of the peer, and mailpit now answers `553 5.1.3 The address is not a valid RFC 5321 address` to `"odd user"@example.com` — which RFC 5321 §4.1.2 explicitly allows. The relay is not at fault; its own log shows it handing the address over verbatim.

So adding the mechanism without touching that test would have produced a permanently red Dependabot PR. Four commits:

1. The test asks the relay what it relayed, not the peer what it kept. Passes on v1.27.11 and v1.31.0. (`raw_headers` goes with it — sole caller.)
2. `tests/mailpit.Dockerfile`, never built, holds the `FROM` line; the fixture reads the tag out of it; `dependabot.yml` gains a `docker` entry on `/tests`.
3. The bump the mechanism would produce on its first run: v1.27.11 → v1.31.0.
4. Invariant 32, because three details of the setup look arbitrary and undo the whole thing if tidied.

**Verified rather than assumed:** the file name works because dependabot-core matches `f.name.match?(/dockerfile|containerfile/i)` — an unanchored substring match, read from the source since the docs are silent on it. The fetcher does not recurse (`repo_contents(dir: ".")` on the configured directory), which is why the entry must name `/tests` and why the base-image entry on `/` is neither affected nor duplicated. A missing anchor raises `FileNotFoundError`, one without a `FROM` line raises `RuntimeError` — a silent fallback would have restored exactly the invisible constant this removes. Full suite green against both v1.27.11 and v1.31.0, and after merging current master: 237 passed, 1 skipped.

The one thing not observable from outside: that a `docker` entry on `/tests` actually produces a pull request. Everything upstream of it is.