### PR TITLE
Snapshot the log after the last line start-up writes

### DIFF
--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -247,12 +247,16 @@ def test_the_check_writes_nothing_to_the_log(relay_factory):
     them is what keeps a connect and a disconnect out of the log each time.
     """
     relay = relay_factory()
-    # rsyslogd writes its own start line once it has finished starting, which
-    # is after "run" has started postfix and can be after the relay answers,
-    # the moment the factory calls it started. Snapshotting before that line
-    # lands leaves it to arrive during the loop below, where it reads as a
-    # line the health check wrote.
-    before = wait_for_log(relay, "rsyslogd:")
+    # Start-up is not over when the relay answers, which is the moment the
+    # factory calls it started, and the snapshot has to be taken after the
+    # last line it writes or that line arrives during the loop below and
+    # reads as one the health check wrote. Two things land late: rsyslogd
+    # writes its own start line once it has finished starting, and "run"
+    # then asks smtpd for a greeting, which logs a connect and the disconnect
+    # below. The disconnect is the last of them -- the probe sends QUIT
+    # rather than dropping the connection precisely so that it is a
+    # disconnect and not a lost connection.
+    before = wait_for_log(relay, "disconnect from localhost")
 
     for _ in range(5):
         assert run_healthcheck(relay, expected=0)[0] == 0


### PR DESCRIPTION
Closes #264 

test_the_check_writes_nothing_to_the_log takes its "before" snapshot when "rsyslogd:" appears, on the reasoning that rsyslogd's own start line is the one that lands after the relay already answers. That was true when it was written. It stopped being true when the start-up greeting probe was added for #206: the probe runs *after* rsyslogd is started, so it writes two more lines after that one. On the built image:

  2: rsyslogd: ... start
  3: postfix/smtpd[494]: connect from localhost[127.0.0.1]
  4: postfix/smtpd[494]: disconnect from localhost[127.0.0.1] quit=1 commands=1

The snapshot is anchored on line 2, so lines 3 and 4 can arrive during the loop below it, where they read as lines the health check wrote -- which is the one thing this test exists to deny.

Measured by replicating the fixture and then the test against a real container, eight times on an idle machine: the snapshot was taken before the probe's lines in three runs of eight. The test nonetheless fails only rarely, and the reason is incidental rather than sound -- poll_until sleeps 0.2s between looks, which is usually longer than the gap, so the lines have landed by the time it looks again. Under load the gap widens and the interval stops covering it, which is where the two failures seen so far came from.

Anchoring on the disconnect removes the timing question instead of narrowing it: it is the last line start-up writes, and the probe sends QUIT rather than dropping the connection precisely so that it is a disconnect and not a lost connection.

Tested on the built image: tests/test_healthcheck.py is 14 passed, three times in a row, and the suite is 237 passed, 1 skipped.