### PR TITLE
Take the mailpit that accepts a quoted local part again

### DIFF
--- a/tests/mailpit.Dockerfile
+++ b/tests/mailpit.Dockerfile
@@ -11,4 +11,4 @@
 #
 # tests/ is excluded by .dockerignore, so this never reaches the build context
 # of the image itself.
-FROM axllent/mailpit:v1.31.0
+FROM axllent/mailpit:v1.31.1

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -277,11 +277,13 @@ def test_a_quoted_local_part_is_relayed(postfix, mailpit):
 
     Read from what the relay handed to the next hop rather than from what the
     next hop did with it. Those are different questions, and only the first is
-    this image's: mailpit answers "553 5.1.3 The address is not a valid RFC
-    5321 address" to this recipient from v1.28.3 on, so asserting on the
-    stored message made the test a test of the peer, and pinned the suite to
-    a mailpit older than that. The peer is still asked for, so that this is a
-    real delivery attempt to a server that is there rather than a deferral.
+    this image's. That is also what keeps the assertion steady while the peer
+    changes its mind about the recipient: mailpit answered "553 5.1.3 The
+    address is not a valid RFC 5321 address" to it from v1.28.3 until the fix
+    in v1.31.1 (axllent/mailpit#731), which held the pin down for four minor
+    versions back when the assertion read the stored message. The peer is
+    still asked for, so that this is a real delivery attempt to a server that
+    is there rather than a deferral.
     """
     send(postfix, recipients=('"odd user"@example.com',), subject='quoted local part')
 


### PR DESCRIPTION
Closes #274

`axllent/mailpit` v1.31.1 carries the fix for the behaviour reported from here as [axllent/mailpit#731](https://github.com/axllent/mailpit/issues/731): *"Allow SP inside quoted local-parts per RFC 5321"*.

From v1.28.3 to v1.31.0 the peer answered `553 5.1.3 The address is not a valid RFC 5321 address` to `"odd user"@example.com`, which is the recipient `test_a_quoted_local_part_is_relayed` sends to. Measured on the two images, the same conversation to each:

```
v1.31.0  RCPT TO:<"odd user"@example.com>  553 5.1.3 The address is not a valid RFC 5321 address
v1.31.1  RCPT TO:<"odd user"@example.com>  250 2.1.5 Ok
```

The suite does not need the fix — `2eae729` moved that assertion onto the relay's own log, which is what freed the pin in the first place — so this is the bump the weekly Dependabot entry would offer, taken with the reason attached. The same release also fixes an SMTP data-reader desync (*"Pass line-boundary state to drainData"*), and the peer is what every relayed message in the suite goes through. Its other addition, `--allowed-hosts`, changes nothing here: unset is the default, an unset allowlist accepts any `Host`, et loopback names and raw IP addresses are allowed regardless of it, which is all the API client in `tests/fixtures/mailpit.py` uses.

The docstring goes with it, because it stated a fact about the peer that the fix ends: the 553 range is now closed at v1.31.1 and names the upstream issue. What it still says is the part that was never about the bug — this image is answerable for handing the address over as it was given, not for what the next hop does with it. Reading the stored message back would work again on v1.31.1 and is still the wrong assertion.

Tested on the built image: the whole suite against `axllent/mailpit:v1.31.1` is **237 passed, 1 skipped**, the same result the pin it replaces was taken on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tSWu9aw9bPwSNo8mZTgiU