### PR TITLE
Record the checks that gate a merge as a ruleset export

### DIFF
--- a/.github/rulesets/master.json
+++ b/.github/rulesets/master.json
@@ -1,0 +1,37 @@
+{
+  "name": "master",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "~DEFAULT_BRANCH"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Build Image"
+          },
+          {
+            "context": "Pytest"
+          },
+          {
+            "context": "Pytest (arm64)"
+          },
+          {
+            "context": "ShellCheck"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,7 +4,9 @@
 # Requirements:
 # - "Allow auto-merge" enabled in the repository settings
 # - a ruleset on master with required status checks, otherwise auto-merge
-#   does not wait for CI and merges straight away
+#   does not wait for CI and merges straight away. The one this expects is
+#   committed as .github/rulesets/master.json, in the form github's
+#   "Import a ruleset" takes.
 #
 # Required checks are matched by job name, not by workflow name. The names
 # that exist are "Build Image", "Pytest", "Pytest (arm64)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ why merge commits name someone else's namespace.
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
-| `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment is also where the check names are recorded. |
+| `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment records the check names that *exist* and the two repository settings it depends on; which of them are *required* is the ruleset below. |
 | `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`, `docker` weekly on `/tests` for the mailpit anchor. |
+| `.github/rulesets/master.json` | The `master` ruleset in github's export/import form: the four required status checks and nothing else. Conditioned on `~DEFAULT_BRANCH` rather than a literal `refs/heads/master`, so renaming the default branch does not quietly stop gating it. Nothing in the tree reads the file — it is the record that makes "CI blocks a bad pull request" checkable instead of believed, and it is what gets imported under Settings > Rules. |
 
 There is no `CONTRIBUTING.md`, no linter *config* of any kind — `lint.yml`
 passes its one flag on the command line — and no per-file license header — see
@@ -256,10 +257,35 @@ Notes a contributor will hit:
 - **Required checks match the job's `name:`**, never the workflow name and
   never the job key. Both `ci.yml` and `test.yml` still key their job `docker`;
   commit `f148d33` added the display names precisely because both reported a
-  check called "docker". Which checks are actually *required* lives in a
-  repository ruleset, not in this tree — the header comment in
-  `dependabot-auto-merge.yml` records the candidate names and explicitly rules
-  the emulated job out of the list.
+  check called "docker". Which checks are actually *required* is
+  `.github/rulesets/master.json`, an export of the `master` ruleset in the form
+  github's "Import a ruleset" takes and re-exports, so what gates a merge can be
+  diffed against the setting rather than taken on trust. Four are required:
+  **Build Image**, **Pytest**, **Pytest (arm64)** and **ShellCheck**. Renaming a
+  job means editing that file in the same commit — no check catches that drift,
+  and a required context naming a job that no longer reports blocks every pull
+  request until someone with admin rights notices.
+- **Three of the seven checks are deliberately not required**, and the reasons
+  are the point of writing the list down. **Test Results** is published by
+  `test-results.yml` on a `workflow_run` whose job carries
+  `if: conclusion == 'success' || conclusion == 'failure'`, and `test.yml`
+  cancels in-flight runs on every ref but `master` — so a push that supersedes a
+  run leaves that job *skipped*, which github counts as a satisfied required
+  check. A check that can pass by not running is the false assurance this list
+  exists to remove, and its verdict is derived anyway: it republishes the junit
+  files **Pytest** already failed on. **Event File** uploads an artifact and
+  reaches no verdict at all. **Pytest (arm/v7, emulated)** does not run on a
+  pull request unless it is labelled `test-emulated`, which nearly none are; the
+  header comment in `dependabot-auto-merge.yml` ruled it out first.
+- **The ruleset carries that one rule and no bypass actors.**
+  `strict_required_status_checks_policy` is false, so a branch does not have to
+  be brought up to date with `master` before it merges — with dependabot
+  auto-merge on, requiring it would re-run every open branch on each merge for a
+  repository whose pull requests do not touch each other. Force-push, deletion,
+  required-review and required-pull-request rules are all absent on purpose:
+  recording what already gates a merge is one thing, and changing the policy is
+  another. Each `context` omits `integration_id`, so which app may report a
+  check is settled in the import dialog rather than by an id pinned here.
 - **The pytest step has `timeout-minutes: 10`** inside a 20-minute job (25/45
   for the emulated one). The job timeouts are backstops: a cancelled job skips
   the upload step, so the bound expected to fire is the step's. Every wait in


### PR DESCRIPTION
Closes #271.

Which checks are required lived only in repository settings. Worse than a docs gap: `dependabot-auto-merge.yml` says in its header it needs a ruleset with required status checks, "otherwise auto-merge does not wait for CI and merges straight away".

**Adds `.github/rulesets/master.json`** — the ruleset in github's export/import form, so the setting can be diffed against the tree instead of believed. Targets `~DEFAULT_BRANCH`, not `refs/heads/master`, so a default-branch rename can't silently un-gate it. `CLAUDE.md` gets a Layout row and replaces its "not in this tree" sentence; the auto-merge header now points at the file.

**Required:** Build Image, Pytest, Pytest (arm64), ShellCheck.

**Not required — one difference from the issue.** I dropped **Test Results**. It's published on `workflow_run` by a job gated `if: conclusion == 'success' || conclusion == 'failure'`, and `test.yml` cancels in-flight runs on every ref but master — so a superseding push leaves it *skipped*, which github counts as satisfied. A required check that passes by not running is the false assurance this file exists to remove, and its verdict is derived from Pytest's anyway. Happy to add it back. Event File reaches no verdict; Pytest (arm/v7, emulated) needs the `test-emulated` label. All three exclusions are recorded with their reasons.

**Carries nothing else:** `strict_required_status_checks_policy: false`, no bypass actors, no force-push/deletion/required-review/required-PR rules — recording what already gates a merge, not changing policy. The last 30 first-parent commits on master are all PR merges, so nothing changes how anyone works. `integration_id` omitted, so the reporting app is picked in the import dialog.

**Inert until imported** — that needs admin rights, filed separately.

**Verified:** JSON parses; all four contexts match a real job display `name:` (the failure mode that matters, since `ci.yml` and `test.yml` both still key their job `docker`); all five workflows parse as YAML. No shell, Dockerfile or test touched.

Not done: nothing in CI pins contexts against job names, so a rename means editing both. A test would be the first needing no docker daemon, and widening the shellcheck gate is ruled out by `CLAUDE.md` — your call, not smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DBtkMV2jKtgjVemdz45xk