### PR TITLE
Assert the next hop took the quoted address

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -212,6 +212,23 @@ def wait_for_log(container, text, timeout=DEFAULT_TIMEOUT):
                       timeout=timeout, description=f"{text!r} in the container log")
 
 
+def wait_for_log_line(container, text, timeout=DEFAULT_TIMEOUT):
+    """Wait for a line in the container log and return that line.
+
+    wait_for_log hands back the whole log, which on a shared relay is where
+    every other test's deliveries are written too: a second assertion made
+    against that string holds for any message rather than for this one.
+    Returning the line is what makes two things asserted about a delivery
+    have to be true of the same delivery.
+    """
+    def line():
+        return next((entry for entry in container_log(container).splitlines()
+                     if text in entry), None)
+
+    return poll_until(line, timeout=timeout,
+                      description=f"{text!r} on a line in the container log")
+
+
 def wait_for_file(container, path, text, timeout=DEFAULT_TIMEOUT):
     """Wait for a file in the container to contain text and return it."""
     def content():

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -13,7 +13,7 @@ import threading
 import pytest
 
 from tests.helpers import (esmtp_features, postconf, send, send_raw, smtp_connect,
-                           wait_for_log)
+                           wait_for_log, wait_for_log_line)
 
 
 def raw_body(mailpit, message):
@@ -281,15 +281,22 @@ def test_a_quoted_local_part_is_relayed(postfix, mailpit):
     changes its mind about the recipient: mailpit answered "553 5.1.3 The
     address is not a valid RFC 5321 address" to it from v1.28.3 until the fix
     in v1.31.1 (axllent/mailpit#731), which held the pin down for four minor
-    versions back when the assertion read the stored message. The peer is
-    still asked for, so that this is a real delivery attempt to a server that
-    is there rather than a deferral.
+    versions back when the assertion read the stored message. Reading it back
+    is still the wrong question even now that the peer accepts the address:
+    mailpit unquotes the local part in what its API returns, so what it hands
+    over is its parser's idea of the address rather than the one that went
+    over the wire.
+
+    status=sent on the same line is the next hop saying it took the message,
+    which the log carries and the stored copy does not. On the line, and not
+    on the log, because this relay is shared: every other test in this file
+    writes status=sent into it, so the two halves have to be one delivery.
     """
     send(postfix, recipients=('"odd user"@example.com',), subject='quoted local part')
 
-    handed_over = wait_for_log(postfix, 'to=<"odd user"@example.com>')
+    delivery = wait_for_log_line(postfix, 'to=<"odd user"@example.com>')
 
-    assert 'to=<"odd user"@example.com>' in handed_over
+    assert 'status=sent' in delivery
 
 
 def test_an_address_with_a_plus_is_relayed_untouched(postfix, mailpit):


### PR DESCRIPTION
Closes #278

`test_a_quoted_local_part_is_relayed` waited for `to=<"odd user"@example.com>` in the relay's log and then asserted the string it had just waited for, so the only thing it could fail on was the address never being handed over. What the next hop answered was deliberately out of it: mailpit refused that recipient from v1.28.3 to v1.31.0, and `2eae729` moved the assertion onto the log precisely so the test said the same thing on both sides of [axllent/mailpit#731](https://github.com/axllent/mailpit/issues/731). With the fix taken in `50e27b2` (#275) the delivery completes for real, so the rest of that line is there to be read.

`status=sent` is the rest of it: the next hop saying it took the message, the half the log has and the stored copy does not. Measured by moving the pin back to v1.31.0, the test now fails in 6.5s on

```
to=<"odd user"@example.com>, ..., dsn=5.1.3, status=bounced (host mailpit said:
  553 5.1.3 The address is not a valid RFC 5321 address (in reply to RCPT TO command))
```

where before it passed.

The assertion is on the line and not on the log, which is what `wait_for_log_line` is for. The relay is shared, so every other test in this file writes `status=sent` into that log — and so does this message when it fails: the bounce notification back to the sender is itself a delivery, logged as `to=<sender@example.com>, ..., status=sent` on that same run. A whole-log assertion would have held exactly when the delivery did not, which is worse than not asserting it at all. The helper sits next to `wait_for_log`, returns the matching line rather than the whole log, and goes through `poll_until` with a description like every other wait here.

Still not reading the stored message back, and now for a second reason: mailpit unquotes the local part in what its API returns — `"odd user"@example.com` comes back as `odd user@example.com` in both `To` and the envelope-derived `Bcc` — so the address it reports is its parser's, not the one que went over the wire.

Tested on the built image: the whole suite is **237 passed, 1 skipped**, and `tests/test_smtp.py` alone is **28 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tSWu9aw9bPwSNo8mZTgiU