### PR TITLE
Start on state the last released image wrote

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,21 +47,24 @@ updates:
     schedule:
       interval: weekly
 
-  # The mailpit image, which is the server every relayed message is read back
-  # from. It lives in a string in tests/fixtures/mailpit.py, and no ecosystem
-  # reads Python, so tests/mailpit.Dockerfile names it where this one looks --
+  # The two images the suite runs beside the one it builds: mailpit, the server
+  # every relayed message is read back from, and the last released
+  # postfix-relay, which the upgrade tests start first so that this tree's
+  # image reads state an older one wrote. Both live in a string in
+  # tests/fixtures, and no ecosystem reads Python, so tests/mailpit.Dockerfile
+  # and tests/upgrade-from.Dockerfile name them where this one looks --
   # dependabot's docker file fetcher matches any file whose name contains
-  # "dockerfile" -- and the fixture reads the tag back out of that file. The
-  # directory has to be named: the fetcher lists the one it is given and does
-  # not recurse, so the base image entry on "/" neither sees this file nor is
-  # disturbed by it.
+  # "dockerfile", and it lists a directory rather than a single name, so one
+  # entry covers both -- and the fixtures read the tags back out of them. The
+  # directory has to be named: the fetcher does not recurse, so the base image
+  # entry on "/" neither sees these files nor is disturbed by them.
   #
   # Unlike the base image above, a bump here is an ordinary semver minor or
   # patch, so the auto-merge rule applies to it. That is the right way round:
-  # this is the test peer rather than the shipped image, every one of these
-  # pull requests runs the whole suite against the new mailpit, and the suite
-  # is the only thing that can say whether it still answers as the tests
-  # expect. One that does not stays red and waits for a person.
+  # these are test peers rather than the shipped image, every one of these
+  # pull requests runs the whole suite against the new one, and the suite is
+  # the only thing that can say whether it still behaves as the tests expect.
+  # One that does not stays red and waits for a person.
   - package-ecosystem: docker
     directory: /tests
     schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,18 +39,19 @@ why merge commits name someone else's namespace.
 | `tests/helpers.py` | The shared vocabulary — `poll_until`, `once_across_workers`, `wait_for_smtp`, `send`, `container_exec`, `postconf`, `listening_ports`, `exit_code_within` and the rest. Imported by every test module but `test_sendmail.py`, and by three of the four fixture modules. `file_missing` is defined and never called. |
 | `tests/requirements.txt` | Six pinned packages: `dkimpy`, `docker`, `pytest`, `pytest-xdist`, `requests`, `testcontainers[mailpit]`. `dkimpy` is what satisfies `import dkim`, so grepping module names against this file looks like a miss when it is not. |
 | `tests/fixtures/shared_network.py` | Session-scoped `shared_network`: a testcontainers `Network()` with a generated, labelled name — not a fixed one, so an interrupted run leaves nothing for the next one to collide with. |
-| `tests/fixtures/postfix.py` | Six fixtures: `postfix_image`, `postfix` and `_relay_pool` (session, the last being the per-configuration relay pool); `postfix_factory`, `postfix_shared` and `docker_volume` (function). Every relay gets `POSTFIX_relayhost=mailpit:1025`, set before the caller's env so a test can override it; readiness is an SMTP connection, not a log line. Reads `POSTFIX_RELAY_IMAGE` / `POSTFIX_RELAY_ARCH`. |
+| `tests/fixtures/postfix.py` | Seven fixtures: `postfix_image`, `published_image`, `postfix` and `_relay_pool` (session, the last being the per-configuration relay pool); `postfix_factory`, `postfix_shared` and `docker_volume` (function). Every relay gets `POSTFIX_relayhost=mailpit:1025`, set before the caller's env so a test can override it; readiness is an SMTP connection, not a log line. Reads `POSTFIX_RELAY_IMAGE` / `POSTFIX_RELAY_ARCH`, and the released image out of `tests/upgrade-from.Dockerfile`. |
 | `tests/mailpit.Dockerfile` | Not built and no part of any image. One `FROM axllent/mailpit:<tag>` line, so that Dependabot's docker ecosystem — whose file fetcher matches any name containing `dockerfile` — can offer a bump to the test peer. `tests/fixtures/mailpit.py` reads the tag back out of it. |
+| `tests/upgrade-from.Dockerfile` | The other unbuilt anchor: one `FROM mwader/postfix-relay:<version>` line, read back by `tests/fixtures/postfix.py`, naming the released image `tests/test_upgrade.py` starts before the one built from the tree. A release and not `latest` — see invariant 33. |
 | `tests/fixtures/mailpit.py` | The remote-SMTP stand-in, whose image is read from `tests/mailpit.Dockerfile` rather than written here: a `Mailpit` REST client class plus `mailpit_image` and `mailpit_container` (session), `mailpit` and `mailpit_factory` (function). Also rebinds the library's `wait_for_logs` to a `functools.partial` with a shorter poll interval. |
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
-| `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`. Each has a row in the README's per-file table. |
+| `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`, `upgrade`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
 | `.github/workflows/ci.yml` | `name: ci`. One job, `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
 | `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment is also where the check names are recorded. |
-| `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`, `docker` weekly on `/tests` for the mailpit anchor. |
+| `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`, `docker` weekly on `/tests`, which covers both anchors there. |
 
 There is no `CONTRIBUTING.md`, no linter *config* of any kind — `lint.yml`
 passes its one flag on the command line — and no per-file license header — see
@@ -95,6 +96,13 @@ tests/test_*.py
                                                                     │
                                           tests/mailpit.Dockerfile ─┘
                                           (the tag, where dependabot can see it)
+
+         test_upgrade.py ──> published_image (session)
+                                 └── docker pull, for the platform of the
+                                     image under test
+                                          │
+                        tests/upgrade-from.Dockerfile ─┘
+                        (the released version, where dependabot can see it)
 
          docker_volume (function)   -- takes no fixtures; creates and removes
                                        a docker volume and nothing else
@@ -675,3 +683,25 @@ changing any of them.
     `FROM` line: a fallback to a version written in the module would work
     perfectly and restore exactly the invisible constant this replaces.
     (issue #235)
+
+33. **The image `tests/test_upgrade.py` upgrades *from* is a release, and the
+    module asks that image what it can do rather than comparing versions.**
+    `tests/upgrade-from.Dockerfile` is the second anchor of the kind 32
+    describes, and the same directory entry in `.github/dependabot.yml`
+    already covers it — the fetcher lists a directory rather than a name.
+    What is different is which tag it may hold.
+    `mwader/postfix-relay:latest` is rebuilt from `master` on every merge, so
+    on `master` it *is* the image under test and the upgrade is one to itself;
+    it also moves with nothing in the tree recording that it did, which leaves
+    a failure impossible to attribute. A release stays put until the line is
+    edited, and it is what deployments actually run. The cost is that it lags
+    the tree by whatever has been merged since: SRS landed after 1.2.17, so
+    the released image never wrote a secret, and the SRS test skips itself
+    saying so instead of passing. It decides that by reading the released
+    image's own `run` for `POSTSRSD_`, not by comparing version numbers, so it
+    starts running of its own accord the first time the anchor moves past the
+    release that adds the feature. And `published_image` pulls for the
+    platform of the image under test rather than the machine's: with
+    `POSTFIX_RELAY_IMAGE` naming a foreign image, the machine's own would put
+    the upgrade between two architectures and pass either way, which is the
+    silence 30 exists to stop. (issue #267)

--- a/README.md
+++ b/README.md
@@ -747,6 +747,13 @@ that file is never built, it exists so that Dependabot can offer a bump to a
 version the tests otherwise name only in Python, and `tests/fixtures/mailpit.py`
 reads the tag back out of it.
 
+The upgrade tests pull one more image: the last released `mwader/postfix-relay`,
+which they start first so that the state it leaves behind is read back by the
+image built from the tree rather than by another container of the same build.
+Its version is pinned in `tests/upgrade-from.Dockerfile`, the same way and for
+the same reason as mailpit's. A release rather than `latest`, because `latest`
+is rebuilt from `master` on every merge and would be the image under test.
+
 ```bash
 # Create and enable python virtual environment
 python -m venv venv
@@ -819,6 +826,7 @@ against a native run.
 | `test_capabilities.py` | Relaying with everything docker grants by default taken away but the documented set |
 | `test_secrets.py` | Configuration read from a file instead of the environment, and what the health check still expects |
 | `test_qshape.py` | The queue tool the troubleshooting section has users run |
+| `test_upgrade.py` | Starting on the state the last released image wrote, which is what the "Upgrading" section promises |
 
 Use the `postfix` fixture for a relay with the default configuration,
 `postfix_shared` for a configuration several tests read the same way, and

--- a/tests/fixtures/postfix.py
+++ b/tests/fixtures/postfix.py
@@ -32,6 +32,31 @@ PREBUILT_IMAGE = os.environ.get('POSTFIX_RELAY_IMAGE')
 # is the one way an emulated run can be worse than no run at all.
 EXPECTED_ARCHITECTURE = os.environ.get('POSTFIX_RELAY_ARCH')
 
+
+def _published_image():
+    """The released image an upgrade starts from, read from the anchor file.
+
+    tests/upgrade-from.Dockerfile names it where Dependabot looks and says why
+    it is a release rather than "latest"; this reads the tag back out, so the
+    version is written once and a bump is one line in one file.
+
+    A missing or unparseable anchor raises, for the reason the mailpit one
+    does: a fallback written here would be a constant that works and that
+    nothing updates.
+    """
+    anchor = os.path.join(os.path.dirname(__file__), os.pardir, 'upgrade-from.Dockerfile')
+
+    with open(anchor, encoding='utf-8') as lines:
+        for line in lines:
+            if line.startswith('FROM '):
+                return line[len('FROM '):].strip()
+
+    raise RuntimeError(f"no FROM line to read the published image from in {anchor}")
+
+
+PUBLISHED_IMAGE = _published_image()
+
+
 # Containers sharing a network need distinct aliases.
 _alias_numbers = itertools.count(1)
 
@@ -67,6 +92,51 @@ def postfix_image(tmp_path_factory):
         lambda: DockerImage(path=ROOT_PATH, tag=IMAGE_TAG).build())
 
     return IMAGE_TAG
+
+
+def _platform(image):
+    """The platform of a local image, spelled the way a pull takes one."""
+    attrs = docker.from_env().images.get(image).attrs
+    parts = [attrs['Os'], attrs['Architecture']]
+    if attrs.get('Variant'):
+        parts.append(attrs['Variant'])
+    return '/'.join(parts)
+
+
+def _pull_published(platform):
+    """Fetch the released image for a platform, unless it is already here.
+
+    The same trade as the mailpit fixture makes: the tag names an exact
+    version, so an image that is here is the image a pull would bring, and
+    asking again spends one of the hundred anonymous pulls Docker Hub allows
+    per six hours for nothing. The platform is compared as well as the name,
+    because the copy an earlier run left behind may be this machine's own
+    rather than the one being asked for.
+    """
+    try:
+        if _platform(PUBLISHED_IMAGE) == platform:
+            return
+    except docker.errors.ImageNotFound:
+        pass
+
+    docker.from_env().images.pull(PUBLISHED_IMAGE, platform=platform)
+
+
+@pytest.fixture(scope="session")
+def published_image(postfix_image, tmp_path_factory):
+    """The last released image, fetched once for the whole run.
+
+    Pulled for the platform of the image under test rather than for the
+    machine's. With POSTFIX_RELAY_IMAGE naming a foreign image, the machine's
+    own would put the upgrade between two architectures and pass either way,
+    which is the silence POSTFIX_RELAY_ARCH exists to stop.
+    """
+    platform = _platform(postfix_image)
+
+    once_across_workers(tmp_path_factory, "published-image",
+                        lambda: _pull_published(platform))
+
+    return PUBLISHED_IMAGE
 
 
 def _start(image, network, env=None, files=None, volumes=None, ports=(25,), alias=None,
@@ -138,13 +208,15 @@ def postfix_factory(postfix_image, shared_network, request):
     "command" replaces the image's own, for the few tests that have to stand
     the image up differently from the way it ships. "wait_ready" can be turned
     off for containers that are not expected to come up at all, and "kwargs" is
-    passed to docker as is.
+    passed to docker as is. "image" stands up another image than the one under
+    test, which only the upgrade tests want: they write the state with the
+    released image before the one built from the tree reads it.
     """
     started = []
 
     def start(env=None, files=None, volumes=None, ports=(25,), alias=None, command=None,
-              wait_ready=True, kwargs=None):
-        return _start(postfix_image, shared_network, env=env, files=files,
+              wait_ready=True, kwargs=None, image=None):
+        return _start(image or postfix_image, shared_network, env=env, files=files,
                       volumes=volumes, ports=ports, alias=alias, command=command,
                       wait_ready=wait_ready, kwargs=kwargs, register=started.append)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,7 @@ import re
 import smtplib
 import time
 
+import dkim
 import docker
 import requests
 
@@ -195,6 +196,16 @@ def dkim_dns_record(container, domain, selector):
     """
     text = container_exec(container, ["cat", f"/etc/opendkim/keys/{domain}/{selector}.txt"])
     return "".join(re.findall(r'"([^"]*)"', text))
+
+
+def verifies(raw, record):
+    """Whether a signed message validates against the record it points at.
+
+    The public key is handed to the verifier directly instead of being looked
+    up: there is no DNS in the test network, and what has to be checked is that
+    the signature matches the record the container tells the user to publish.
+    """
+    return dkim.verify(raw, dnsfunc=lambda name, **kwargs: record.encode())
 
 
 def container_log(container):

--- a/tests/test_dkim.py
+++ b/tests/test_dkim.py
@@ -6,24 +6,13 @@ issues #14, #63, #78 and #92.
 
 import re
 
-import dkim
 import pytest
 
 from tests.helpers import (container_exec, container_log, container_stderr,
                            dkim_dns_record, exit_code_within, image_run,
-                           listening_sockets, postconf, restart, send)
+                           listening_sockets, postconf, restart, send, verifies)
 
 KEY_PATH = '/etc/opendkim/keys/example.com/sel1.private'
-
-
-def verifies(raw, record):
-    """Whether a signed message validates against the record it points at.
-
-    The public key is handed to the verifier directly instead of being looked
-    up: there is no DNS in the test network, and what has to be checked is that
-    the signature matches the record the container tells the user to publish.
-    """
-    return dkim.verify(raw, dnsfunc=lambda name, **kwargs: record.encode())
 
 
 def test_mail_is_signed_for_configured_domains_only(postfix_factory, mailpit):

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,131 @@
+"""Starting on state an older image wrote.
+
+Pulling a newer image replaces the whole filesystem, so what an upgrade
+actually asks is whether the state left behind is still readable: the queue
+and the DKIM keys in the two volumes, and the SRS secret in the file the
+README says to mount. The Upgrading section promises all three survive.
+
+Everywhere else in the suite the container that writes that state and the one
+that reads it are the same build, which is a restart rather than an upgrade
+and cannot fail the way an upgrade fails. Here the state is written by the
+last released image -- tests/upgrade-from.Dockerfile names it -- and read by
+the one built from the tree, so a base suite bump that moves the queue
+layout, the uid postfix runs as or the key directory has somewhere to show up
+before it reaches a deployment.
+
+Which release that is decides what can be covered: SRS landed after the one
+named there, so the secret half of this skips itself until the anchor moves
+past it, and says so rather than passing.
+"""
+
+import pytest
+
+from tests.helpers import (container_exec, container_log, dkim_dns_record, image_run,
+                           send, verifies, wait_for_log)
+
+SRS_DOMAIN = 'srs.example.com'
+
+
+def test_the_queue_the_older_image_left_is_delivered_by_this_one(published_image,
+                                                                 docker_volume,
+                                                                 postfix_factory,
+                                                                 mailpit_factory):
+    """Mail accepted before the upgrade has been promised to its sender.
+
+    The next hop being down is what keeps it in the queue long enough to be
+    upgraded over, and is also the reason a user upgrades with mail in flight
+    at all.
+    """
+    env = {'POSTFIX_relayhost': 'upgrade-target:1025'}
+    volumes = {docker_volume: '/var/spool/postfix'}
+
+    older = postfix_factory(image=published_image, env=env, volumes=volumes)
+    send(older, subject='queued before the upgrade')
+    wait_for_log(older, 'status=deferred')
+    older.get_wrapped_container().stop()
+
+    upgraded = postfix_factory(env=env, volumes=volumes)
+
+    assert 'receiver@example.com' in container_exec(upgraded, ["postqueue", "-p"])
+
+    target = mailpit_factory('upgrade-target')
+    container_exec(upgraded, ["postqueue", "-f"])
+
+    assert target.wait_for_message('queued before the upgrade')
+
+
+def test_the_key_the_older_image_generated_still_signs(published_image, docker_volume,
+                                                       postfix_factory, mailpit):
+    """The published DNS record has to stay valid across an upgrade.
+
+    It is the half of DKIM that is not in the image: the record was handed to
+    a DNS zone, and a new image that generated a key of its own would leave
+    every signature it makes failing verification until someone noticed and
+    published the new record.
+    """
+    env = {'OPENDKIM_DOMAINS': 'example.com=sel1'}
+    volumes = {docker_volume: '/etc/opendkim/keys'}
+
+    older = postfix_factory(image=published_image, env=env, volumes=volumes)
+    published = dkim_dns_record(older, 'example.com', 'sel1')
+    older.get_wrapped_container().stop()
+
+    upgraded = postfix_factory(env=env, volumes=volumes)
+
+    assert 'Generating one now' not in container_log(upgraded)
+
+    send(upgraded, sender='sender@example.com', subject='signed after the upgrade',
+         body='signed body')
+    raw = mailpit.raw(mailpit.wait_for_message('signed after the upgrade')['ID'])
+
+    assert verifies(raw, published)
+
+
+@pytest.fixture
+def older_image_that_rewrites(published_image):
+    """The released image, or a skip while it is older than SRS itself.
+
+    SRS was added after the release tests/upgrade-from.Dockerfile names, so
+    no deployment is upgrading from a release that ever wrote a secret and
+    there is nothing yet for the test below to carry across. Asked of the
+    image rather than written as a version to compare against: it starts
+    running of its own accord the first time the anchor moves to a release
+    that has the feature.
+    """
+    knows_srs = image_run(published_image, [
+        "bash", "-c", "grep -q POSTSRSD_ /root/run && echo yes || echo no"])
+
+    if 'yes' not in knows_srs:
+        pytest.skip(f"{published_image} has no SRS, so it left no secret to reuse")
+
+    return published_image
+
+
+def test_addresses_the_older_image_rewrote_still_reverse(older_image_that_rewrites,
+                                                         postfix_factory, mailpit):
+    """A bounce can arrive days after the upgrade that replaced the relay.
+
+    Return addresses are signed with /etc/postsrsd.secret, which is not in a
+    volume: the README has users mount it, and this mounts what the older
+    image generated. What has to hold is that the new postsrsd reverses an
+    address the old one signed, rather than merely signing new ones of its own.
+    """
+    env = {'POSTSRSD_SRS_DOMAIN': SRS_DOMAIN}
+
+    older = postfix_factory(image=older_image_that_rewrites, env=env)
+    send(older, sender='sender@example.com', subject='forwarded before the upgrade')
+    rewritten = mailpit.wait_for_message('forwarded before the upgrade')['ReturnPath']
+    assert rewritten.startswith('SRS0=')
+
+    secret = container_exec(older, ["cat", "/etc/postsrsd.secret"])
+    older.get_wrapped_container().stop()
+
+    upgraded = postfix_factory(env=env, files={'/etc/postsrsd.secret': secret})
+
+    send(upgraded, sender='', recipients=(rewritten,), subject='the bounce after the upgrade')
+
+    message = mailpit.wait_for_message('the bounce after the upgrade')
+
+    # The envelope is what was decoded, which is what makes the bounce
+    # deliverable; mailpit reports it as a Bcc because it matches no header.
+    assert [to['Address'] for to in message['Bcc']] == ['sender@example.com']

--- a/tests/upgrade-from.Dockerfile
+++ b/tests/upgrade-from.Dockerfile
@@ -1,0 +1,20 @@
+# Not built, and no part of any image. This file exists so that the version of
+# the released image the upgrade tests start from can be seen by a bot that
+# only understands Dockerfiles, the same reason tests/mailpit.Dockerfile is
+# here: Dependabot's docker ecosystem matches any file whose name contains
+# "dockerfile", and .github/dependabot.yml already points one at this
+# directory, which lists every file it matches rather than a single name.
+#
+# tests/fixtures/postfix.py reads the tag back out of the line below, so this
+# is the one place the version is written.
+#
+# A release and not "latest", which is the other image this could name.
+# "latest" is rebuilt from master on every merge, so on master it is the very
+# image under test and an upgrade to itself proves nothing; it also moves
+# without anything in the tree recording that it did, which is what makes a
+# failure impossible to attribute. A release stays put until this line is
+# changed, and it is what people are actually upgrading from.
+#
+# tests/ is excluded by .dockerignore, so this never reaches the build context
+# of the image itself.
+FROM mwader/postfix-relay:1.2.17


### PR DESCRIPTION
Closes #267.

## What was missing

The image declares two volumes and generates an SRS secret on first start, and the README's *Upgrading* section promises all of it is still there after pulling a newer image. Nothing tested that.

The three tests that reuse state across containers — the queue in `test_lifecycle.py`, the keys in `test_dkim.py`, the secret in `test_srs.py` — all put the **same build** on both sides of the handover. That is a restart: it cannot fail the way an upgrade fails, because the code that reads the state is the code that wrote it. The risk is not theoretical — a Debian suite bump arrives here as a one-line `FROM` and takes the postfix version, the queue layout and the postfix uid with it.

## What this adds

`tests/test_upgrade.py` starts the last released image against a fresh volume, lets it write its state, stops it, and starts the image built from the tree on the same volume:

| Test | What it pins |
| --- | --- |
| `test_the_queue_the_older_image_left_is_delivered_by_this_one` | Mail accepted before the upgrade is still in the queue afterwards, and still gets delivered |
| `test_the_key_the_older_image_generated_still_signs` | The DNS record the old container told the user to publish still verifies mail the new one signs |
| `test_addresses_the_older_image_rewrote_still_reverse` | An SRS return address signed before the upgrade still reverses after it |

## Which image it upgrades from

Pinned in `tests/upgrade-from.Dockerfile`, the second anchor of the kind `tests/mailpit.Dockerfile` already is. The docker file fetcher matches any name containing `dockerfile` and lists a directory rather than a name, so the existing `/tests` entry in `dependabot.yml` covers it with **no configuration change** — only its comment is updated.

It names a **release** rather than `:latest`, which was the other candidate. `:latest` is rebuilt from `master` on every merge, so on `master` it is the very image under test and the upgrade is one to itself; it also moves with nothing in the tree recording that it did, which leaves a failure impossible to attribute. Building `origin/master` locally instead would be deterministic and need no registry, but it doubles the build per run and never asks the question users actually ask, which is about a version from months ago.

The cost of a release is that it lags the tree: **SRS landed after 1.2.17**, so the released image never wrote a secret and there is no such upgrade to test yet. The SRS test skips itself with that reason rather than passing, and decides by reading the released image's own `run` for `POSTSRSD_` instead of comparing version numbers — so it starts running by itself the first time Dependabot moves the anchor past the release that adds the feature.

## Other details

- `published_image` pulls for the platform of the image under test rather than the machine's. With `POSTFIX_RELAY_IMAGE` naming a foreign image, the machine's own would put the upgrade between two architectures and pass either way, which is the silence `POSTFIX_RELAY_ARCH` exists to stop. The pull is skipped when that exact image and platform are already present, for the reason the mailpit one is: Docker Hub allows a hundred anonymous pulls per six hours.
- `postfix_factory` takes an `image=` argument; everything else about it is unchanged.
- `verifies()` moves from `test_dkim.py` to `helpers.py`, where `dkim_dns_record` — the other half of the same check — already lives, now that two modules use it.
- README gets the per-file table row and a paragraph in *Testing*; `CLAUDE.md` gets the layout rows, the dependency graph and invariant 33.

## Verification

- `pytest` locally → **239 passed, 2 skipped** in 2m54s, against 238 passed before.
- CI on this branch → **Build Image** green on all three architectures, **Pytest** et **Pytest (arm64)** green, 241 tests / 240 passed / 1 skipped / 0 failed on each, **ShellCheck** green.
- With the anchor temporarily pointed at `mwader/postfix-relay:latest`, which does have SRS, all three upgrade tests pass — so the skipping one is known to work rather than merely known to skip. The anchor was put back to 1.2.17 afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qse8Hgqa967LcWqzL2BJZs