### PR TITLE
Cover the two _FILE prefixes only the docstring named

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,7 +520,14 @@ changing any of them.
     *"configuration error at line N: unrecognized parameter"*. It is not the
     only name that has to stay out: any `OPENDKIM_<name>_FILE` would land there
     too, and does not only because `secretsFromFiles` unsets the `_FILE`
-    variable after reading it. That `unset` is part of this invariant.
+    variable after reading it. That `unset` is part of this invariant, and
+    `tests/test_secrets.py` now pins it: one test there asserts that a
+    `POSTFIX_<name>_FILE` leaves no `<name>_FILE` in `main.cf` and that a
+    `POSTFIXMASTER_` one draws no `postconf` fatal — the two prefixes where
+    losing the `unset` costs nothing but noise. The prefix where it costs the
+    whole file is this one, and the relay in that same file configured through
+    `OPENDKIM_DOMAINS_FILE` is what catches that: without the `unset` it does
+    not come up at all.
 
 16. **`dkimConfig` deletes `/etc/opendkim/KeyTable` and
     `/etc/opendkim/SigningTable` before rebuilding them**, because the loop
@@ -538,7 +545,7 @@ changing any of them.
     exactly five prefixes — `POSTFIX_`, `POSTFIXMASTER_`, `POSTMAP_`,
     `OPENDKIM_` and `POSTSRSD_`. `SASL_Passwds`, `POSTMASTER_ADDRESS` and the
     `RSYSLOG_*` variables have no `_FILE` form, and `tests/test_secrets.py`
-    names the same five.
+    exercises the same five.
 
 18. **The POSTMAP loop is wrapped in `shopt -s nullglob` / `shopt -u nullglob`,
     and chowns the table and everything `postmap` generated from it to

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -11,12 +11,17 @@ import pytest
 from testcontainers.community.mailpit import MailpitUser
 
 from tests.helpers import (container_exec, container_log, container_stderr,
-                           exit_code_within, healthcheck_after_stopping, send)
+                           esmtp_features, exit_code_within, healthcheck_after_stopping,
+                           postconf, send)
 
 UPSTREAM = '[secrets-upstream]:1025'
 USER, PASSWORD = 'relay', 's3cret'
 SECRET = '/run/secrets/sasl_passwd'
 SASL_PASSWD = f"{UPSTREAM} {USER}:{PASSWORD}\n"
+
+HOSTNAME, HOSTNAME_SECRET = 'smtp.from-a-file.test', '/run/secrets/myhostname'
+SUBMISSION = 'submission inet n - y - - smtpd'
+SUBMISSION_SECRET = '/run/secrets/submission'
 
 
 def healthcheck(container):
@@ -43,6 +48,23 @@ def relay(postfix_factory, upstream):
             'POSTMAP_sasl_passwd_FILE': SECRET,
         },
         files={SECRET: SASL_PASSWD})
+
+
+@pytest.fixture
+def settings_from_files(postfix_shared):
+    """Relay taking a POSTFIX_ and a POSTFIXMASTER_ setting from a file.
+
+    Shared, because the three tests below only read it back. The other three
+    prefixes are configured separately elsewhere in this file: one loop reads
+    all five, but only the reading is shared -- what each of them does with the
+    value afterwards is a different piece of code every time.
+    """
+    return postfix_shared(
+        env={
+            'POSTFIX_myhostname_FILE': HOSTNAME_SECRET,
+            'POSTFIXMASTER_submission__inet_FILE': SUBMISSION_SECRET,
+        },
+        files={HOSTNAME_SECRET: f"{HOSTNAME}\n", SUBMISSION_SECRET: f"{SUBMISSION}\n"})
 
 
 def test_a_password_from_a_file_relays_through_an_authenticated_upstream(relay, upstream):
@@ -95,6 +117,43 @@ def test_a_path_that_cannot_be_read_stops_the_container(postfix_factory):
 
     assert exit_code_within(relay, seconds=30) == 1
     assert 'which cannot be read' in container_stderr(relay)
+
+
+def test_a_postfix_setting_from_a_file_is_what_the_relay_runs_with(settings_from_files):
+    assert postconf(settings_from_files, 'myhostname') == HOSTNAME
+
+    # Written into main.cf is not the same as used, and myhostname is a setting
+    # the relay answers with: the greeting is postfix's own reading of it.
+    code, banner, _ = esmtp_features(settings_from_files)
+    assert code == 220
+    assert banner.startswith(f"{HOSTNAME} ESMTP")
+
+
+def test_a_master_cf_service_from_a_file_is_added(settings_from_files):
+    """The service tests/test_config.py adds from the environment, from a file.
+
+    Deliberately the same service and the same assertion: what differs is the
+    route the value took. "__" still stands for "/", because the "_FILE" suffix
+    is stripped off the name before the replacement ever sees it.
+    """
+    assert 'submission inet' in \
+        container_exec(settings_from_files, ["postconf", "-M", "submission/inet"])
+
+
+def test_the_file_variable_itself_configures_nothing(settings_from_files):
+    """The unset that ends secretsFromFiles, part of CLAUDE.md invariant 15.
+
+    Without it every loop below configures "<name>_FILE" as well, and neither
+    of these two stops the container: postfix takes myhostname_FILE into
+    main.cf and mentions it in a warning, and "postconf -Me" refuses
+    submission/inet_FILE with a fatal the script does not see. The prefix that
+    pays for it is OPENDKIM_, where one name opendkim does not know costs the
+    whole configuration file -- the relay below does not come up at all
+    without this unset, which is a loud failure but not one that names it.
+    """
+    assert 'myhostname_FILE' not in \
+        container_exec(settings_from_files, ["cat", "/etc/postfix/main.cf"])
+    assert 'submission/inet_FILE' not in container_stderr(settings_from_files)
 
 
 def test_a_domain_list_from_a_file_is_watched_by_the_health_check(postfix_factory):


### PR DESCRIPTION
secretsFromFiles resolves <NAME>_FILE for five prefixes -- POSTFIX_, POSTFIXMASTER_, POSTMAP_, OPENDKIM_ and POSTSRSD_ -- and tests/test_secrets.py names all five in its module docstring. Only three were ever set by a test: POSTMAP_sasl_passwd_FILE, OPENDKIM_DOMAINS_FILE and POSTSRSD_SRS_DOMAIN_FILE. POSTFIX_<name>_FILE and POSTFIXMASTER_<name>_FILE had none.

The case for leaving it there is that this is one loop with a prefix-agnostic body, so the POSTMAP_ tests already walk every line of it -- the *_FILE filter, the suffix strip, the "is also set" branch, the unreadable-path refusal, the printf -v -- and the only regression a new test can catch is somebody deleting one of two words from the "for file in" list. Measured, that regression is both silent and complete: with "${!POSTFIX_*} ${!POSTFIXMASTER_*}" removed from that line, the suite as it stood is 237 passed, 1 skipped, while myhostname quietly stays at the image default, submission/inet never exists at all, and the container comes up and reports healthy. Two words on one line, with nothing between them and a released image.

Three tests, sharing one relay through postfix_shared because all three only read it back:

  - a POSTFIX_ setting from a file is what the relay runs with. Not postconf alone: myhostname is what the greeting says, so the banner is postfix's own reading of the value rather than main.cf read back.
  - a master.cf service from a file is added -- deliberately the same service and the same assertion as tests/test_config.py, so that what differs is only the route the value took. The "__" to "/" rule and the _FILE suffix meet on one name here and nowhere else.
  - the _FILE variable itself configures nothing, which is the unset that ends secretsFromFiles.

That last one is the half of #270 that was not quite as reported, and it is worth writing down. The unset was already caught for OPENDKIM_: without it, OPENDKIM_DOMAINS_FILE reaches the opendkim.conf rebuild, which skips only the exact name OPENDKIM_DOMAINS, opendkim rejects the whole file, and startService exits 1 above the postfix start -- so the existing domain-list test fails, but on "the container exited with 1 instead of answering on port 25", which reads as an opendkim regression and never names the unset. Through the two prefixes added here it was not caught at all, and both traces are quiet: postconf -e takes a parameter it does not know, so main.cf simply grows "myhostname_FILE = /run/secrets/myhostname" behind an unused-parameter warning, and postconf -Me refuses "submission/inet_FILE=..." with a fatal that run, having no set -e, never sees. The two assertions are on exactly those two traces.

CLAUDE.md 15 gets the test citation its neighbours carry and it had none of, and 17's "names the same five" becomes "exercises the same five", which is now true. README.md is unchanged: no user-visible behaviour moved, and the per-file table already has its row.

Tested on the built image: tests/test_secrets.py is 10 passed and the suite is 240 passed, 1 skipped. Verified against the two mutations these tests exist for. Deleting "unset $file" fails test_the_file_variable_itself_configures_nothing on 'myhostname_FILE' is contained here in main.cf, and, with the assertions reversed to reach it, on

  postconf: fatal: bad field count: "submission/inet_FILE=/run/secrets/submission"

Deleting the two prefixes from the loop fails all three of the new tests -- myhostname reading back as "hostname", postconf answering 'unmatched request: "submission/inet"' -- and, across the whole suite, nothing else.

Closes #270


Claude-Session: https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU