### PR TITLE
Say why a check is not required, rather than counting them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ display `name:`, so on an ordinary pull request it appears as a skipped
 | **ShellCheck** | `lint.yml` | Downloads shellcheck at the version and sha256 pinned in the job's `env:`, then `shellcheck -S error run healthcheck`. Seconds, no docker. See [Lint](#lint) for why that threshold and not a stricter one. |
 | **Test Results** | `test-results.yml` | Runs on `workflow_run` of `test`, downloads the junit artifacts and publishes them onto the PR. |
 
-A seventh, **Pytest (arm/v7, emulated)**, runs only on `master`, on a manual
+**Pytest (arm/v7, emulated)** runs only on `master`, on a manual
 dispatch, or on a pull request labelled `test-emulated` — and the label is read
 from the event that started the run, so it takes effect on the *next* push to
 the branch. It pins the QEMU binfmt image, builds `linux/arm/v7`, and runs
@@ -275,8 +275,8 @@ Notes a contributor will hit:
   job means editing that file in the same commit — no check catches that drift,
   and a required context naming a job that no longer reports blocks every pull
   request until someone with admin rights notices.
-- **Three of the seven checks are deliberately not required**, and the reasons
-  are the point of writing the list down. **Test Results** is published by
+- **Every check that is not on that list is off it for a reason**, and the
+  reasons are the point of writing the list down. **Test Results** is published by
   `test-results.yml` on a `workflow_run` whose job carries
   `if: conclusion == 'success' || conclusion == 'failure'`, and `test.yml`
   cancels in-flight runs on every ref but `master` — so a push that supersedes a
@@ -286,7 +286,10 @@ Notes a contributor will hit:
   files **Pytest** already failed on. **Event File** uploads an artifact and
   reaches no verdict at all. **Pytest (arm/v7, emulated)** does not run on a
   pull request unless it is labelled `test-emulated`, which nearly none are; the
-  header comment in `dependabot-auto-merge.yml` ruled it out first.
+  header comment in `dependabot-auto-merge.yml` ruled it out first. And the two
+  **Verify Published Image** jobs have nothing to report on a branch at all:
+  what they check is the image a push to `master` published, so on a pull
+  request they are skipped by the `if:` that keeps them off it.
 - **The ruleset carries that one rule and no bypass actors.**
   `strict_required_status_checks_policy` is false, so a branch does not have to
   be brought up to date with `master` before it merges — with dependabot


### PR DESCRIPTION
Two pull requests crossed. #276 wrote the ruleset export and, with it, the list of checks that are deliberately not required -- *"three of the seven"*. #281 then added two more, **Verify Published Image (amd64)** and **(arm64)**. Each change was right on its own and they touched different lines, so the merge was clean and `CLAUDE.md` was left saying there are seven checks and three exceptions when there are nine and five.

The two new ones belong on that list for the firmest reason any of them has: they are gated on a push to `master`, so on a pull request there is nothing for them to report at all.

The count goes rather than being corrected to nine, per the rule the file states about itself -- a count rots at the next change, and what it was being used to say (every check off the required list is off it for a reason, and here is each reason) does not. The ordinal in *"A seventh, Pytest (arm/v7, emulated)"* goes with it, for the same reason.

Documentation only: no workflow, script or test is touched, and `shellcheck -S error run healthcheck` has nothing new to read.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
