### PR TITLE
Gate the tests on pyflakes findings

### DIFF
--- a/.github/rulesets/master.json
+++ b/.github/rulesets/master.json
@@ -28,6 +28,9 @@
             "context": "Pytest (arm64)"
           },
           {
+            "context": "Ruff"
+          },
+          {
             "context": "ShellCheck"
           }
         ]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,8 +10,10 @@
 #
 # Required checks are matched by job name, not by workflow name. The names
 # that exist are "Build Image", "Pytest", "Pytest (arm64)",
-# "Pytest (arm/v7, emulated)", "Event File", "Test Results" and "ShellCheck";
-# "ci", "test" and "lint" are workflows and never report a check of their own.
+# "Pytest (arm/v7, emulated)", "Event File", "Test Results", "ShellCheck" and
+# "Ruff"; "ci", "test" and "lint" are workflows and never report a check of
+# their own, and one workflow can report more than one -- "lint" reports both
+# "ShellCheck" and "Ruff".
 #
 # "Pytest (arm/v7, emulated)" does not run on a pull request unless it is
 # labelled "test-emulated", which is nearly all of them, so it is not a

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
-# What this gate is, and what it deliberately is not.
+# What the ShellCheck gate is, and what it deliberately is not.
 #
 # It runs shellcheck at "-S error", which is the threshold the two scripts pass
 # today and the only one that does: "-S warning" fails on the SC2034 in
@@ -27,11 +27,11 @@ concurrency:
 # stricter threshold: raising it would mean changing code that is already
 # correct.
 #
-# shellcheck is pinned and checksummed rather than taken from the runner image,
-# and nothing bumps it. An unpinned linter fails somebody's unrelated pull
-# request on the day it ships a new check; test.yml pins the QEMU binfmt image
-# for the same reason. Moving to a newer shellcheck is a deliberate edit, the
-# way a base-image suite change is.
+# Both linters here are pinned and checksummed rather than taken from the runner
+# image, and nothing bumps them. An unpinned linter fails somebody's unrelated
+# pull request on the day it ships a new check; test.yml pins the QEMU binfmt
+# image for the same reason. Moving to a newer one is a deliberate edit, the way
+# a base-image suite change is.
 
 jobs:
   shellcheck:
@@ -65,3 +65,59 @@ jobs:
         run: |
           shellcheck --version
           shellcheck -S error run healthcheck
+
+  # What the Ruff gate is, and what it deliberately is not.
+  #
+  # It runs ruff over tests/, which is all the python in the tree, at
+  # "--select F" -- pyflakes, the rules that find code which cannot work rather
+  # than code someone would write differently. A name that is not defined, an
+  # import nothing uses, a variable assigned and never read, an f-string with no
+  # placeholder, and a test function silently replaced by a later one of the
+  # same name. That last is the one pytest hides best: it collects the second
+  # definition, the first one's assertions never run, and nothing reports it.
+  #
+  # F is the level the tree passes today with no edit to any .py file, which is
+  # the same decision "-S error" is for the shell: gate at what the code already
+  # meets, and tighten on purpose or not at all. What that leaves out is not
+  # small -- E501 would impose a line length the suite has never had, I001 would
+  # reorder the imports of sixteen files, and "ruff format" would rewrite
+  # nineteen of the twenty-three -- and none of it is a defect today.
+  #
+  # The selection is written out rather than inherited from ruff's default,
+  # because that default is a moving target: on this tree, unchanged, it is two
+  # findings under ruff 0.15.8 and twenty-eight under 0.16.6. "--select F" is
+  # the same on both. Pinning the version is only half of not surprising an
+  # unrelated pull request; naming the rules is the other half.
+  #
+  # --no-cache keeps ruff from leaving a .ruff_cache/ in the checkout, which is
+  # the reason the binary is unpacked into RUNNER_TEMP as well: the tree a step
+  # reads should be only what git has in it.
+  ruff:
+    name: "Ruff"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      RUFF_VERSION: 0.16.6
+      RUFF_SHA256: 0696335ef16615d8c7445ad438750eb0f55b3da6f153df21265a7c6d5750254f
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install ruff
+        run: |
+          set -eu
+          url="https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL -o "${RUNNER_TEMP}/ruff.tar.gz" "$url"
+          echo "${RUFF_SHA256}  ${RUNNER_TEMP}/ruff.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/ruff"
+          tar -xzf "${RUNNER_TEMP}/ruff.tar.gz" \
+            --strip-components=1 -C "${RUNNER_TEMP}/ruff"
+          echo "${RUNNER_TEMP}/ruff" >> "${GITHUB_PATH}"
+
+      - name: Check tests
+        # tests/ is where all the python is, and naming it keeps this gate as
+        # narrow as the one above, which names its two scripts rather than
+        # scanning the tree.
+        run: |
+          ruff --version
+          ruff check --no-cache --select F tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,14 +48,14 @@ why merge commits name someone else's namespace.
 | `.github/workflows/ci.yml` | `name: ci`. One job, `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
-| `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
+| `.github/workflows/lint.yml` | `name: lint`. Two jobs, each pinned and checksummed: `shellcheck`, displayed as **ShellCheck**, runs `shellcheck -S error run healthcheck` — the only threshold the two scripts pass; `ruff`, displayed as **Ruff**, runs `ruff check --no-cache --select F tests` — pyflakes over all the python in the tree. The only two linters there are, and neither reads a config file. |
 | `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment records the check names that *exist* and the two repository settings it depends on; which of them are *required* is the ruleset below. |
 | `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`, `docker` weekly on `/tests` for the mailpit anchor. |
-| `.github/rulesets/master.json` | The `master` ruleset in github's export/import form: the four required status checks and nothing else. Conditioned on `~DEFAULT_BRANCH` rather than a literal `refs/heads/master`, so renaming the default branch does not quietly stop gating it. Nothing in the tree reads the file — it is the record that makes "CI blocks a bad pull request" checkable instead of believed, and it is what gets imported under Settings > Rules. |
+| `.github/rulesets/master.json` | The `master` ruleset in github's export/import form: the five required status checks and nothing else. Conditioned on `~DEFAULT_BRANCH` rather than a literal `refs/heads/master`, so renaming the default branch does not quietly stop gating it. Nothing in the tree reads the file — it is the record that makes "CI blocks a bad pull request" checkable instead of believed, and it is what gets imported under Settings > Rules. |
 
 There is no `CONTRIBUTING.md`, no linter *config* of any kind — `lint.yml`
-passes its one flag on the command line — and no per-file license header — see
-[Conventions](#conventions).
+passes both linters their selection on the command line — and no per-file
+license header — see [Conventions](#conventions).
 
 ## Dependency graph
 
@@ -181,8 +181,11 @@ until CI runs.
 ### Lint
 
 ```bash
-shellcheck -S error run healthcheck   # what CI runs; exits 0
-shellcheck run healthcheck            # everything, at the stock threshold
+shellcheck -S error run healthcheck        # what CI runs; exits 0
+shellcheck run healthcheck                 # everything, at the stock threshold
+
+ruff check --no-cache --select F tests     # what CI runs; exits 0
+ruff check --statistics --select ALL tests # everything ruff has, for reference
 ```
 
 `run` and `healthcheck` are the two scripts that go into the image, and
@@ -192,12 +195,6 @@ stone to a stricter one: it is the only one the scripts pass, and the findings
 between it and the default are either noise or deliberate. The third shell
 script in the tree, the hook under `.claude/`, is not gated: it is no part of
 what ships.
-
-There is still no linter *configuration* anywhere in the repo (no
-`.shellcheckrc`, `.hadolint.yaml`, `pyproject.toml`, `setup.cfg`, `tox.ini`,
-`.flake8`, `.ruff.toml` or `.pre-commit-config.yaml`) and no in-file
-`# shellcheck disable=`, so nothing is suppressed: what the gate lets through,
-it lets through because of the threshold alone.
 
 With shellcheck 0.11.0, which is the version `lint.yml` pins:
 
@@ -230,12 +227,41 @@ as a snapshot; the pin in `lint.yml` is what keeps a release from moving them
 under an unrelated pull request. Nothing bumps that pin — moving to a newer
 shellcheck is a deliberate edit, the way a base-image suite change is.
 
+`tests/` is all the python in the tree, and `lint.yml` gates it at
+`--select F` — pyflakes — as the **Ruff** check. The same decision made twice:
+`F` is the rules that find code which cannot work rather than code someone
+would write differently, and it is what the suite passes with no edit to any
+`.py` file. The one worth naming is `F811`, a test function replaced by a later
+one of the same name — pytest collects the second, the first one's assertions
+never run, and nothing says so. What `F` does *not* buy is worth knowing too:
+a fixture nobody requests is invisible to every pyflakes-family tool, a helper
+whose signature drifted needs pylint, and `file_missing` — the one dead helper
+the tree actually has — is seen at no ruff selection at all, `ALL` included.
+(#268, which asked for the gate, names all three as the thing it would catch.)
+
+Widening is a deliberate edit here too, and it is not free: `E` is 62 `E501`s
+at ruff's 88 columns on a suite whose longest line has always been 102, `I`
+reorders the imports of sixteen files, and `ruff format` would rewrite nineteen
+of the twenty-three. None of that is a defect today. The selection is written
+out rather than left to ruff's default for the same reason the version is
+pinned: on this tree, unchanged, the default is two findings under ruff 0.15.8
+and twenty-eight under 0.16.6, while `--select F` is the same on both. Nothing
+bumps that pin either.
+
+There is still no linter *configuration* anywhere in the repo (no
+`.shellcheckrc`, `.hadolint.yaml`, `pyproject.toml`, `setup.cfg`, `tox.ini`,
+`.flake8`, `.ruff.toml` or `.pre-commit-config.yaml`) and no in-file
+`# shellcheck disable=`, so nothing is suppressed: what the gates let through,
+they let through because of the threshold and the selection alone. The tree's
+one suppression is a `# noqa: BLE001` in `tests/test_smtp.py`, inert under
+`--select F` and written for a rule nothing has ever selected.
+
 ## What blocks a pull request
 
 Four workflow files carry a `pull_request` trigger, but `dependabot-auto-merge.yml`
 is a no-op for anything not opened by `dependabot[bot]` — its single job has no
 display `name:`, so on an ordinary pull request it appears as a skipped
-`auto-merge` check. The six that can actually fail are:
+`auto-merge` check. The seven that can actually fail are:
 
 | Check | From | What it does |
 | --- | --- | --- |
@@ -244,6 +270,7 @@ display `name:`, so on an ordinary pull request it appears as a skipped
 | **Pytest (arm64)** | `test.yml` | The same, natively, on `ubuntu-24.04-arm`. |
 | **Event File** | `test.yml` | Uploads the triggering event payload for the reporter. |
 | **ShellCheck** | `lint.yml` | Downloads shellcheck at the version and sha256 pinned in the job's `env:`, then `shellcheck -S error run healthcheck`. Seconds, no docker. See [Lint](#lint) for why that threshold and not a stricter one. |
+| **Ruff** | `lint.yml` | The same shape, one job over: downloads ruff at the version and sha256 pinned in the job's `env:`, then `ruff check --no-cache --select F tests`. Seconds, no docker. See [Lint](#lint) for why that selection and not a wider one, and why it is spelled out rather than inherited. |
 | **Test Results** | `test-results.yml` | Runs on `workflow_run` of `test`, downloads the junit artifacts and publishes them onto the PR. |
 
 A seventh, **Pytest (arm/v7, emulated)**, runs only on `master`, on a manual
@@ -260,12 +287,14 @@ Notes a contributor will hit:
   check called "docker". Which checks are actually *required* is
   `.github/rulesets/master.json`, an export of the `master` ruleset in the form
   github's "Import a ruleset" takes and re-exports, so what gates a merge can be
-  diffed against the setting rather than taken on trust. Four are required:
-  **Build Image**, **Pytest**, **Pytest (arm64)** and **ShellCheck**. Renaming a
-  job means editing that file in the same commit — no check catches that drift,
+  diffed against the setting rather than taken on trust. Five are required:
+  **Build Image**, **Pytest**, **Pytest (arm64)**, **Ruff** and **ShellCheck**.
+  A workflow can report more than one of them — `lint.yml` reports the last
+  two. Renaming a job means editing that file in the same commit — no check
+  catches that drift,
   and a required context naming a job that no longer reports blocks every pull
   request until someone with admin rights notices.
-- **Three of the seven checks are deliberately not required**, and the reasons
+- **Three of the eight checks are deliberately not required**, and the reasons
   are the point of writing the list down. **Test Results** is published by
   `test-results.yml` on a `workflow_run` whose job carries
   `if: conclusion == 'success' || conclusion == 'failure'`, and `test.yml`
@@ -301,10 +330,13 @@ Notes a contributor will hit:
   The Python dependencies are pinned exactly (`tests/requirements.txt`); their
   transitive dependencies are not, and there is no lock file, so a run can
   still break without a change in this repo.
-- **ShellCheck is a gate, but a narrow one.** It fails only on shellcheck
-  errors in `run` and `healthcheck` — nothing about python, yaml, the
-  `Dockerfile` or the README is linted anywhere. Do not widen it as a side
-  effect of an unrelated change: `-S warning` fails on master today.
+- **Both linters are gates, but narrow ones.** **ShellCheck** fails only on
+  shellcheck errors in `run` and `healthcheck`; **Ruff** only on pyflakes
+  findings under `tests/`. Nothing about yaml, the `Dockerfile` or the README is
+  linted anywhere, and python outside `tests/` would not be either — the job
+  names the directory. Do not widen either as a side effect of an unrelated
+  change: `-S warning` fails on master today, and every ruff selection past `F`
+  costs edits to files that are not wrong.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -863,6 +863,23 @@ That threshold is the whole gate. Warnings and notes below it are left
 alone, some of them deliberately, so raising it would mean changing code
 that is already correct.
 
+The tests themselves are python, and pytest only reads the lines it runs, so
+they are linted the same way -- with [ruff](https://docs.astral.sh/ruff/), at
+the pyflakes rules:
+
+```bash
+ruff check --select F tests
+```
+
+Same idea as the threshold above: those are the rules that find code which
+cannot work, rather than code someone would write differently. A name that is
+not defined, an import nothing uses, a variable assigned and never read, and a
+test function silently replaced by a later one of the same name -- the last one
+being invisible in a pytest run, which simply collects the second definition
+and never reports the first. Style, import order and formatting are not
+checked, and widening the selection would mean changing code that is already
+correct.
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- LICENSE -->


### PR DESCRIPTION
tests/ is 4,682 lines of python, and nothing has ever read them but pytest, which only reads the lines it runs. shellcheck has gated the two shell scripts since #239; this is the same gate for the other half of the tree.

The selection is F -- pyflakes -- for the reason -S error is the shell's threshold: it is what the code already passes, so the gate arrives without editing a file that is not wrong. Everything wider costs edits that are pure style. E is 62 E501s at ruff's 88 columns on a suite whose longest line has always been 102; I reorders the imports of sixteen files; ruff format would rewrite nineteen of the twenty-three. Ruff's own default set would have cost two E402s in tests/fixtures/mailpit.py, and would have been the wrong shape of thing to depend on besides: on this tree, unchanged, it is two findings under ruff 0.15.8 and twenty-eight under 0.16.6. Naming the rules is the half of not surprising an unrelated pull request that pinning the version does not cover.

What F buys is not hypothetical. F811 is the one to know about: two test functions of the same name in one file and pytest collects the second, while the first one's assertions never run -- no error, no warning, one fewer test than the file appears to hold. F821 reaches the code pytest does not, the failure-only branches a green run never executes.

What it does not buy is worth saying too, because #268 named three things and this catches one of them. A fixture nobody requests is invisible to every pyflakes-family tool; a helper whose signature drifted needs pylint; and file_missing, the one dead helper the tree has, is reported at no ruff selection at all, ALL included. None of the three is present today, so nothing here is a fix -- the gate is to keep the fourth one out.

ruff is downloaded at a pinned version, verified against a pinned sha256 and unpacked into RUNNER_TEMP, exactly as shellcheck is, and nothing bumps it. The ruleset export, the check-name list in the auto-merge header, CLAUDE.md and the README all name the new check.

Verified on the tree: the workflow's install block, run verbatim with RUNNER_TEMP and GITHUB_PATH set, fetches ruff 0.16.6 and matches the sha256, and "ruff check --no-cache --select F tests" then exits 0 leaving no .ruff_cache behind in the checkout. Against a copy of tests/ with one defect of each class planted in test_qshape.py the same command reports F401, F841, F821, F541 and F811 and exits 1, so the gate is not vacuous. shellcheck -S error still exits 0 on run and healthcheck.

Closes #268


Claude-Session: https://claude.ai/code/session_01QoXNxkLNasHDPWfHy46r8g