### PR TITLE
Pin the required checks against the jobs that report them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,14 +36,14 @@ why merge commits name someone else's namespace.
 | `.claude/hooks/session-start.sh` | Starts the docker daemon and installs `tests/requirements.txt`, because a Claude Code on the web container has neither and both gates need them. Guarded on `CLAUDE_CODE_REMOTE=true`, so a local checkout is untouched, and best-effort: a failed step explains itself on stderr and the hook still exits 0, so check stderr before believing a build or test failure. |
 | `tests/__init__.py` | Empty; makes `tests` a package, which is what lets `conftest.py` name plugins as `tests.fixtures.*` and lets modules do `from tests.helpers import …`. pytest therefore has to be run from the repo root. There is no `tests/fixtures/__init__.py`. |
 | `tests/conftest.py` | Registers the four fixture modules as pytest plugins, and defines the failure plumbing: `print_log_on_failure`, an autouse `shared_container_logs` fixture, and a `pytest_runtest_makereport` wrapper hook that stashes the report on the item. |
-| `tests/helpers.py` | The shared vocabulary — `poll_until`, `once_across_workers`, `wait_for_smtp`, `send`, `container_exec`, `postconf`, `listening_ports`, `exit_code_within` and the rest. Imported by every test module but `test_sendmail.py`, and by three of the four fixture modules. `file_missing` is defined and never called. |
-| `tests/requirements.txt` | Six pinned packages: `dkimpy`, `docker`, `pytest`, `pytest-xdist`, `requests`, `testcontainers[mailpit]`. `dkimpy` is what satisfies `import dkim`, so grepping module names against this file looks like a miss when it is not. |
+| `tests/helpers.py` | The shared vocabulary — `poll_until`, `once_across_workers`, `wait_for_smtp`, `send`, `container_exec`, `postconf`, `listening_ports`, `exit_code_within` and the rest. Imported by every test module but `test_sendmail.py` and `test_ruleset.py`, and by three of the four fixture modules. `file_missing` is defined and never called. |
+| `tests/requirements.txt` | Seven pinned packages: `dkimpy`, `docker`, `pytest`, `pytest-xdist`, `pyyaml`, `requests`, `testcontainers[mailpit]`. `dkimpy` is what satisfies `import dkim`, so grepping module names against this file looks like a miss when it is not; `pyyaml` is there for `test_ruleset.py` alone. |
 | `tests/fixtures/shared_network.py` | Session-scoped `shared_network`: a testcontainers `Network()` with a generated, labelled name — not a fixed one, so an interrupted run leaves nothing for the next one to collide with. |
 | `tests/fixtures/postfix.py` | Six fixtures: `postfix_image`, `postfix` and `_relay_pool` (session, the last being the per-configuration relay pool); `postfix_factory`, `postfix_shared` and `docker_volume` (function). Every relay gets `POSTFIX_relayhost=mailpit:1025`, set before the caller's env so a test can override it; readiness is an SMTP connection, not a log line. Reads `POSTFIX_RELAY_IMAGE` / `POSTFIX_RELAY_ARCH`. |
 | `tests/mailpit.Dockerfile` | Not built and no part of any image. One `FROM axllent/mailpit:<tag>` line, so that Dependabot's docker ecosystem — whose file fetcher matches any name containing `dockerfile` — can offer a bump to the test peer. `tests/fixtures/mailpit.py` reads the tag back out of it. |
 | `tests/fixtures/mailpit.py` | The remote-SMTP stand-in, whose image is read from `tests/mailpit.Dockerfile` rather than written here: a `Mailpit` REST client class plus `mailpit_image` and `mailpit_container` (session), `mailpit` and `mailpit_factory` (function). Also rebinds the library's `wait_for_logs` to a `functools.partial` with a shorter poll interval. |
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
-| `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`. Each has a row in the README's per-file table. |
+| `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `ruleset`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
 | `.github/workflows/ci.yml` | `name: ci`. One job, `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
@@ -51,7 +51,7 @@ why merge commits name someone else's namespace.
 | `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
 | `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment records the check names that *exist* and the two repository settings it depends on; which of them are *required* is the ruleset below. |
 | `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`, `docker` weekly on `/tests` for the mailpit anchor. |
-| `.github/rulesets/master.json` | The `master` ruleset in github's export/import form: the four required status checks and nothing else. Conditioned on `~DEFAULT_BRANCH` rather than a literal `refs/heads/master`, so renaming the default branch does not quietly stop gating it. Nothing in the tree reads the file — it is the record that makes "CI blocks a bad pull request" checkable instead of believed, and it is what gets imported under Settings > Rules. |
+| `.github/rulesets/master.json` | The `master` ruleset in github's export/import form: the four required status checks and nothing else. Conditioned on `~DEFAULT_BRANCH` rather than a literal `refs/heads/master`, so renaming the default branch does not quietly stop gating it. `tests/test_ruleset.py` is what keeps it true; nothing else in the tree reads it. It is the record that makes "CI blocks a bad pull request" checkable instead of believed, and it is what gets imported under Settings > Rules. |
 
 There is no `CONTRIBUTING.md`, no linter *config* of any kind — `lint.yml`
 passes its one flag on the command line — and no per-file license header — see
@@ -76,7 +76,8 @@ pytest.ini ──addopts──> pytest-xdist   (-n auto --dist loadfile --maxpro
 
 tests/test_*.py
     │
-    ├──> tests/helpers.py         (every module but test_sendmail.py)
+    ├──> tests/helpers.py         (every module but test_sendmail.py and
+    │                              test_ruleset.py, which starts no container)
     │        └── once_across_workers  -> builds/pulls the image once per RUN,
     │                                     not once per xdist worker
     └──> fixtures, registered in tests/conftest.py as pytest_plugins:
@@ -156,8 +157,10 @@ it only ever builds the host's — follow the cross-build recipe in
 [README.md](README.md#testing). It pins the same binfmt image CI does, so a
 failure there means the same thing.
 
-There is no unit test layer: nothing runs without a docker daemon. Most tests
-start a real relay; the exception is `test_image.py`, which starts none — it
+One module runs without a docker daemon: `test_ruleset.py`, which reads
+`.github/rulesets/master.json` and the workflows and starts nothing. Everything
+else needs one. Most tests start a real relay; the exception is
+`test_image.py`, which starts none — it
 reads `docker inspect` output through `image_config`, asks a throwaway `sleep`
 container about the image's files through its `image_shell` fixture, and runs a
 command in one with `image_run`. When a test fails, `conftest.py` prints the
@@ -262,9 +265,10 @@ Notes a contributor will hit:
   github's "Import a ruleset" takes and re-exports, so what gates a merge can be
   diffed against the setting rather than taken on trust. Four are required:
   **Build Image**, **Pytest**, **Pytest (arm64)** and **ShellCheck**. Renaming a
-  job means editing that file in the same commit — no check catches that drift,
-  and a required context naming a job that no longer reports blocks every pull
-  request until someone with admin rights notices.
+  job means editing that file in the same commit, which `tests/test_ruleset.py`
+  is there to catch: a required context naming a job that no longer reports
+  blocks every pull request until someone with admin rights notices, and that
+  test fails on the rename instead.
 - **Three of the seven checks are deliberately not required**, and the reasons
   are the point of writing the list down. **Test Results** is published by
   `test-results.yml` on a `workflow_run` whose job carries

--- a/README.md
+++ b/README.md
@@ -819,6 +819,7 @@ against a native run.
 | `test_capabilities.py` | Relaying with everything docker grants by default taken away but the documented set |
 | `test_secrets.py` | Configuration read from a file instead of the environment, and what the health check still expects |
 | `test_qshape.py` | The queue tool the troubleshooting section has users run |
+| `test_ruleset.py` | The required status checks recorded in `.github/rulesets/master.json`, against the jobs that report them |
 
 Use the `postfix` fixture for a relay with the default configuration,
 `postfix_shared` for a configuration several tests read the same way, and

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,5 +10,6 @@ dkimpy==1.1.8
 docker==7.2.0
 pytest==9.1.1
 pytest-xdist==3.8.0
+pyyaml==6.0.3
 requests==2.34.2
 testcontainers[mailpit]==4.15.0

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -1,0 +1,63 @@
+"""The checks that gate a merge, against the jobs that report them.
+
+`.github/rulesets/master.json` records the required status checks so the gate
+can be checked rather than believed. These tests are what keep that record
+true: a required check is matched by a job's display `name:`, so renaming a
+job without editing the ruleset leaves a context that never reports, and a
+context that never reports blocks every pull request until someone with admin
+rights notices.
+
+Unlike every other module here these tests read files and start nothing, so
+they are the one part of the suite that needs no docker daemon.
+"""
+
+import json
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RULESET = REPO_ROOT / ".github" / "rulesets" / "master.json"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def ruleset():
+    return json.loads(RULESET.read_text())
+
+
+def required_contexts():
+    rules = [r for r in ruleset()["rules"] if r["type"] == "required_status_checks"]
+    assert len(rules) == 1, f"expected one required_status_checks rule, got {len(rules)}"
+    return [c["context"] for c in rules[0]["parameters"]["required_status_checks"]]
+
+
+def job_display_names():
+    """Every check name a workflow can report, mapped to the file reporting it.
+
+    A job without a `name:` reports under its key -- that is how the
+    auto-merge job appears -- so the key is the default rather than a skip.
+    """
+    names = {}
+    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        for key, job in yaml.safe_load(workflow.read_text())["jobs"].items():
+            names[job.get("name", key)] = workflow.name
+    return names
+
+
+def test_every_required_check_names_a_job_that_exists():
+    reported = job_display_names()
+    missing = [c for c in required_contexts() if c not in reported]
+    assert not missing, (
+        f"required contexts naming no job: {missing}. Such a context never "
+        f"reports and blocks every pull request. Names that do report: "
+        f"{sorted(reported)}"
+    )
+
+
+def test_the_ruleset_still_gates_the_default_branch():
+    """A re-export made after fiddling in the web UI can bring back a file
+    that records a gate which does not gate."""
+    recorded = ruleset()
+    assert recorded["enforcement"] == "active"
+    assert recorded["conditions"]["ref_name"]["include"] == ["~DEFAULT_BRANCH"]
+    assert recorded["bypass_actors"] == []


### PR DESCRIPTION
Closes #286.

`.github/rulesets/master.json` names four checks by their job display `name:`, and nothing kept those names honest. Rename a job — what `f148d33` did, when `ci.yml` and `test.yml` both reported a check called "docker" — and the ruleset goes on requiring a context that no longer reports. Github doesn't fall back to the new name, it waits: every pull request then sits blocked on a check that will never arrive. A record that can quietly stop matching the tree is back to being believed, which is what the file was committed to stop.

**`tests/test_ruleset.py`** reads the ruleset and the workflows and asserts every required context matches a job that exists, the failure naming the ones that do report so the fix is the diff. A second test pins the file's shape — active, `~DEFAULT_BRANCH`, no bypass actors — because a re-export taken after fiddling in the web UI can bring back a file recording a gate that doesn't gate.

A separate CI job would have been worse: its own required context to add, and `lint.yml` is deliberately narrow — `CLAUDE.md` rules out widening the shellcheck gate as a side effect. Riding in `Pytest` and `Pytest (arm64)`, already required, costs no new check and no minutes.

**Two consequences, recorded rather than left to be discovered.** This is the first module that starts no container, so the first that runs without a docker daemon — `CLAUDE.md`'s claim that nothing does is corrected, not left to rot. And it needs a yaml parser: `tests/requirements.txt` gains a seventh pin, `pyyaml`, used by this module alone. A regex over the workflows would have avoided it and would have depended on their indentation — the sort of thing that breaks quietly.

**Verified:** both tests pass against the pinned pytest 9.1.1 and pyyaml 6.0.3, with no docker daemon running. Renaming `lint.yml`'s job to "Shellcheck" fails the first test with `required contexts naming no job: ['ShellCheck']` — the failure this exists to catch — and restoring it passes again. README's per-file table, `CLAUDE.md`'s module list, helpers-import note, dependency graph, requirements count and the two sentences this makes wrong are all updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DBtkMV2jKtgjVemdz45xk