### PR TITLE
Tie the sent-report test to its own delivery

### DIFF
--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -345,14 +345,21 @@ def test_a_refused_message_leaves_the_session_usable(smtp, mailpit):
 
 def test_a_message_the_relay_accepted_is_reported_as_sent(postfix, mailpit):
     """status=sent in the log is what an operator greps for, and it has to
-    mean the next hop took the message."""
-    send(postfix, subject='logged as sent')
+    mean the next hop took the message.
+
+    On its own recipient and its own line, the way the message-id tests
+    above already do it. The relay is shared, so a status=sent and a
+    to=<receiver@example.com> somewhere in its log are as easily another
+    test's delivery as this one's: with the send() below deleted, the
+    assertion this replaces still passed.
+    """
+    send(postfix, recipients=('reported-as-sent@example.com',), subject='logged as sent')
     message = mailpit.wait_for_message('logged as sent')
 
-    log = wait_for_log(postfix, 'status=sent')
+    delivery = wait_for_log_line(postfix, 'to=<reported-as-sent@example.com>')
 
     assert message['ID']
-    assert 'to=<receiver@example.com>' in log
+    assert 'status=sent' in delivery
 
 
 def test_the_queue_is_empty_once_the_mail_is_gone(postfix, mailpit):


### PR DESCRIPTION
Closes #288

`test_a_message_the_relay_accepted_is_reported_as_sent` waited for `status=sent` anywhere in the relay's log and then asserted `to=<receiver@example.com>` anywhere in it. The relay is the shared one, so both strings are in that log several times over before this test runs, from every other delivery in the file. Measured on master by deleting this test's own `send()` and the message it reads back: **the assertion still passed**, on another test's message.

It now sends to a recipient of its own, the way the two message-id tests above already do, and reads the line that recipient produced through `wait_for_log_line` (#279) rather than the whole log. The same deletion against this version fails, naming what is missing:

```
AssertionError: timed out after 30s waiting for
  'to=<reported-as-sent@example.com>' on a line in the container log
```

The peer is still asked for the message, because that is what gives `status=sent` its meaning here: the log line says the next hop answered 250, and mailpit having the message is the other half of what "took it" means.

Checked while here: this is the only test with the problem. Every other `wait_for_log` caller either runs against a relay of its own or already sends to a recipient no other test uses.

Tested on the built image: the whole suite is **237 passed, 1 skipped**, and `tests/test_smtp.py` alone is **28 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tSWu9aw9bPwSNo8mZTgiU