### PR TITLE
Run the arm/v7 smoke tests before a merge, not after

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,9 +11,12 @@
 # "Pytest (arm/v7, emulated)", "Event File", "Test Results" and "ShellCheck";
 # "ci", "test" and "lint" are workflows and never report a check of their own.
 #
-# "Pytest (arm/v7, emulated)" does not run on a pull request unless it is
-# labelled "test-emulated", which is nearly all of them, so it is not a
-# candidate for the required list whatever github makes of a skipped check.
+# All seven run on every pull request now. "Pytest (arm/v7, emulated)" was not
+# a candidate while it sat behind a "test-emulated" label, because a required
+# check that is skipped gates on a run that did not happen; #273 removed the
+# label. Whether it is required is a ruleset setting this file cannot make:
+# auto-merge waits for what the ruleset names and for nothing else, so a red
+# emulated check stops a minor or patch update only once it is added there.
 
 name: Dependabot auto-merge
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - 'master'
   pull_request:
-  # So the emulated job below can be asked for without pushing anything.
+  # So the workflow can be asked for on a branch with no pull request open,
+  # which is the only way left to reach the emulated job without one.
   workflow_dispatch:
 
 concurrency:
@@ -106,16 +107,27 @@ jobs:
     # recompiled: Debian builds no postsrsd for armhf, so the image ships
     # without it and "run" refuses to start when SRS is asked for anyway.
     #
-    # Emulation is slow and its failures are harder to read than real ones, so
-    # this stays off the path a pull request waits on: master, a manual run, or
-    # a pull request labelled "test-emulated" for the changes that want it. The
-    # label is read from the event that started the run, so it takes effect on
-    # the next push to the branch; "labeled" is deliberately not a trigger here,
-    # because Dependabot labels its pull requests as it opens them and the
-    # concurrency group above would have that cancel the run it just started.
-    if: >-
-      github.event_name != 'pull_request'
-      || contains(github.event.pull_request.labels.*.name, 'test-emulated')
+    # It runs on a pull request like the two native ones, and used not to: it
+    # sat behind a "test-emulated" label, read from the event that started the
+    # run, so the label took effect on the next push and the one architecture
+    # whose packaging differs was the only one whose tests ran after the merge.
+    # "Build Image" does build all three, but the Dockerfile has no RUN below
+    # the COPY, so a build starts neither script and no daemon: "run"'s
+    # start-up budgets, the greeting probe, the supervision loop and the health
+    # check are all invisible to it.
+    #
+    # Emulation is slow, but not on the scale that kept this off the path.
+    # Measured over seven runs on master the job takes 42-152s end to end,
+    # against 174-275s for either native pytest job, so a pull request waits on
+    # those and never on this one; the slowest of the seven is the run whose
+    # Dockerfile changed, where the build step is an emulated build rather than
+    # a cache hit. The runner is free on a public repository.
+    #
+    # Its failures are still harder to read than a native run's, which is why
+    # running it is all this asks for: it reports, a person looks, and a QEMU
+    # artefact costs a second look instead of a merge. Whether it also blocks
+    # one is a ruleset decision, which no file here can take -- see the header
+    # in dependabot-auto-merge.yml.
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,22 +234,17 @@ shellcheck is a deliberate edit, the way a base-image suite change is.
 Four workflow files carry a `pull_request` trigger, but `dependabot-auto-merge.yml`
 is a no-op for anything not opened by `dependabot[bot]` — its single job has no
 display `name:`, so on an ordinary pull request it appears as a skipped
-`auto-merge` check. The six that can actually fail are:
+`auto-merge` check. The seven that can actually fail are:
 
 | Check | From | What it does |
 | --- | --- | --- |
 | **Build Image** | `ci.yml` | buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`. Nothing is pushed on a PR — the DockerHub login is skipped, and the build step sets `push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}` — but the build has to succeed on **all three** architectures. The `dependabot[bot]` half of that condition covers the branch push Dependabot makes before opening its pull request: such a run reads Dependabot secrets only, so the Actions secrets the login needs arrive empty. This is the gate that catches architecture-specific packaging problems. |
 | **Pytest** | `test.yml` | `ubuntu-latest`, Python 3.13, `pip install -r tests/requirements.txt`, `pytest --junitxml=junit/test-results.xml`. |
 | **Pytest (arm64)** | `test.yml` | The same, natively, on `ubuntu-24.04-arm`. |
+| **Pytest (arm/v7, emulated)** | `test.yml` | Pins the QEMU binfmt image, builds `linux/arm/v7` and runs `pytest -m smoke -n0` against it — four tests, and the only ones that ever start the image whose packaging differs. It ran on `master` and behind a `test-emulated` label until #273; the label is gone, and 42-152s against 174-275s for either native job is why it can be on the path a pull request waits on without lengthening it. |
 | **Event File** | `test.yml` | Uploads the triggering event payload for the reporter. |
 | **ShellCheck** | `lint.yml` | Downloads shellcheck at the version and sha256 pinned in the job's `env:`, then `shellcheck -S error run healthcheck`. Seconds, no docker. See [Lint](#lint) for why that threshold and not a stricter one. |
 | **Test Results** | `test-results.yml` | Runs on `workflow_run` of `test`, downloads the junit artifacts and publishes them onto the PR. |
-
-A seventh, **Pytest (arm/v7, emulated)**, runs only on `master`, on a manual
-dispatch, or on a pull request labelled `test-emulated` — and the label is read
-from the event that started the run, so it takes effect on the *next* push to
-the branch. It pins the QEMU binfmt image, builds `linux/arm/v7`, and runs
-`pytest -m smoke -n0`.
 
 Notes a contributor will hit:
 
@@ -258,8 +253,11 @@ Notes a contributor will hit:
   commit `f148d33` added the display names precisely because both reported a
   check called "docker". Which checks are actually *required* lives in a
   repository ruleset, not in this tree — the header comment in
-  `dependabot-auto-merge.yml` records the candidate names and explicitly rules
-  the emulated job out of the list.
+  `dependabot-auto-merge.yml` records the candidate names. Since #273 all seven
+  run on every pull request, so all seven are candidates and the ruleset alone
+  decides. #273 asked only that the emulated one run, deliberately leaving
+  whether it is required as a separate decision: a QEMU artefact should cost a
+  second look rather than a merge.
 - **The pytest step has `timeout-minutes: 10`** inside a 20-minute job (25/45
   for the emulated one). The job timeouts are backstops: a cancelled job skips
   the upload step, so the bound expected to fire is the step's. Every wait in

--- a/README.md
+++ b/README.md
@@ -796,10 +796,9 @@ POSTFIX_RELAY_IMAGE=postfix-relay:test-armv7 POSTFIX_RELAY_ARCH=arm \
 CI runs the whole suite on `amd64` and on `arm64`, both natively. There is no
 `arm/v7` runner, so that image is emulated and only the handful of tests
 marked `smoke` run against it -- it starts, reports healthy, relays a message,
-and has no `postsrsd` -- on `master`, on a manual run, or on a pull request
-labelled `test-emulated` before its next push. Emulation is slow enough that
-the rest is not worth its minutes, and every wait in the suite is measured
-against a native run.
+and has no `postsrsd`. That runs on every pull request, like the two native
+runs. Emulation is slow enough that the rest is not worth its minutes, and
+every wait in the suite is measured against a native run.
 
 | File | What it covers |
 | --- | --- |


### PR DESCRIPTION
Closes #273.

The emulated arm/v7 job sat behind a `test-emulated` label, read from the event that started the run, so it only took effect on the next push — in practice the one architecture whose packaging differs was the only one whose tests ran after the merge. This deletes the `if:` so it runs on every pull request, like the two native jobs.

**Cost, measured.** Over seven runs on master the job takes 42–152s end to end against 174–275s for either native pytest job, and it finished first in all seven. Public repo, zero billable minutes. Verified on a run of this branch: all four jobs green, 238 tests, the emulated job 3m22 with a cold cache (2m30 of that the arm/v7 build).

**Two corrections to the issue.** The job's bound is 45 minutes, not 25 (25 is the test step's timeout). And the `schedule:` alternative is not cheaper: `arm_v7` is the only job in `test.yml` carrying an `if:`, so a schedule would fire both native suites on every tick.

**Scope, honestly.** Three of the four smoke tests are architecture-neutral — `9e5ded3` says "all four smoke tests pass unchanged on amd64" — and only `test_postsrsd_is_installed_for_this_architecture` branches on it. What this adds is that the arm/v7 image is started before a merge rather than after, at no cost.

**Not changed:** `.github/rulesets/master.json`. The check reports, it does not gate — emulation still fails in ways that read like real failures, so a QEMU artefact should cost a second look rather than un merge.

Also updated: `README.md`, `CLAUDE.md` et le header `dependabot-auto-merge.yml`. Follow-up: le label `test-emulated` peut être supprimé