### PR TITLE
Read the manifest, not only the entry this runner pulls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,38 @@ jobs:
         env:
           DOCKER_REPO: "${{ secrets.DOCKER_REPO }}"
 
+      - name: Check the published manifest lists every architecture built
+        # This job pulls the entry of the manifest list that matches its own
+        # runner, and the arm64 one its own, so between them an entry that went
+        # missing or came back mislabelled leaves both green while a "docker
+        # pull" on the architecture that lost it fails or fetches something
+        # else. The list is the only place all three are visible at once, and
+        # imagetools reads it straight from the registry, so this costs a
+        # request and runs before anything is pulled.
+        #
+        # "linux/arm64", not the "linux/arm64/v8" the build asks for: v8 is
+        # arm64's default variant and buildx drops it when it writes the
+        # manifest, while arm/v7 keeps its variant because armhf has no
+        # default. That is what this build publishes, read off the manifest
+        # rather than assumed -- manifests written by other tooling do carry
+        # the "/v8". The entries skipped here are the provenance attestations
+        # buildx attaches to a pushed build: they carry platform
+        # "unknown/unknown" and are not architectures. Keep the list in step
+        # with the "platforms:" above.
+        env:
+          TAG: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+        run: |
+          expected="linux/amd64 linux/arm/v7 linux/arm64"
+          published=$(docker buildx imagetools inspect --raw "${TAG}" |
+            jq -r '.manifests[] | select(.platform.os != "unknown") | .platform |
+                   .os + "/" + .architecture + (if .variant then "/" + .variant else "" end)' |
+            sort | tr '\n' ' ' | sed 's/ $//')
+          echo "published: ${published}"
+          if [ "${published}" != "${expected}" ] ; then
+            echo "::error::${TAG} lists ${published}, expected ${expected}"
+            exit 1
+          fi
+
       - name: Pull the published image
         # By tag and without a platform, which is what a user's docker does:
         # the daemon picks the entry of the manifest list that matches this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ why merge commits name someone else's namespace.
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
 | `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
-| `.github/workflows/ci.yml` | `name: ci`. Two jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls the tag that was just pushed and runs `pytest -m smoke` against it. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. |
+| `.github/workflows/ci.yml` | `name: ci`. Three jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls the tag that was just pushed and runs `pytest -m smoke` against it; the amd64 one first asserts the published manifest lists the three platforms the build asks for. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
@@ -260,7 +260,11 @@ the publication the **Build Image** step makes there. Each pulls that tag the
 way a user would and runs `pytest -m smoke` against it — the only check in the
 tree that looks at the artefact on the registry rather than at one built from
 the tree. Nothing is rolled back when one fails; the tag is already out, and
-the check is what says so. (issue #266)
+the check is what says so. (issue #266) The amd64 one carries one step the
+other does not: each job pulls the entry of the manifest list matching its own
+runner, so a missing or mislabelled entry would leave both green while the
+architecture that lost it fails to pull at all — that step reads the list
+itself. (issue #284)
 
 Notes a contributor will hit:
 

--- a/README.md
+++ b/README.md
@@ -816,8 +816,11 @@ All of that tests an image built from the tree. Every push to `master` also
 publishes `latest`, and what reaches the registry is built by buildx rather
 than by the daemon the suite uses, so a check after the push pulls that tag on
 `amd64` and on `arm64` -- the way anyone else pulls it -- and runs the same
-smoke tests against it. It is the only check that looks at the image users
-actually pull. Nothing is rolled back when it fails: the tag is out by then,
+smoke tests against it. It also reads the manifest that tag points at, and
+fails if it does not list all three architectures that were built: each half
+of the check pulls the entry for its own architecture, so the one with no
+runner is only visible there. It is the only check that looks at the image
+users actually pull. Nothing is rolled back when it fails: the tag is out by then,
 and the check is what says so.
 
 | File | What it covers |


### PR DESCRIPTION
Closes #284.

## What is uncovered

The two published-image jobs each pull the tag without a `--platform`, so each gets the entry of the manifest list matching its own runner: amd64 on one, arm64 on the other. That is two of the three entries the build pushes, and the third has no runner to be pulled by. An entry that went missing or came back mislabelled would leave **both jobs green** while a `docker pull` on the architecture that lost it failed outright or fetched something else.

## What this adds

One step in the amd64 job, before anything is pulled: `docker buildx imagetools inspect --raw` on the published tag, et une erreur quand les plateformes ne sont pas les trois attendues. It queries the registry rather than pulling, so it costs a request.

## Two details read off the published manifest rather than assumed

Both are why this is an explicit list and not a comparison against the `platforms:` string:

- buildx **drops the `/v8`** when it writes an arm64 entry -- v8 is arm64's default variant. Manifests written by other tooling do carry it (`hello-world:latest` does), so this is a fact about our own publisher, not about registries.
- a pushed build carries **provenance attestations**, which appear in the list as entries with platform `unknown/unknown`. They are skipped.

A naive `linux/amd64 linux/arm/v7 linux/arm64/v8` would have gone red on its first run.

## Verified by running the step's script exactly as the job will run it

| Input | Result |
| --- | --- |
| `mwader/postfix-relay:latest` | `linux/amd64 linux/arm/v7 linux/arm64`, exit 0 |
| the same manifest with the arm/v7 entry deleted | mismatch named, exit 1 |
| `hello-world:latest` | mismatch named, exit 1 |

## Also in here

The `ci.yml` row in `CLAUDE.md` said *"Two jobs"* while naming three: the count was written when the two published-image jobs were still one matrix. Fixed here because this change edits that same sentence.

`README.md` and the checks section of `CLAUDE.md` get the new step. No script, test or image content is touched.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
