### PR TITLE
Move latest onto the image only once it has been tested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
   docker:
     name: "Build Image"
     runs-on: ubuntu-latest
+    outputs:
+      # What the jobs below pull and what "Publish latest" promotes. A digest
+      # rather than a tag: it names this run's image and cannot be moved by
+      # another run pushing between the build and the promotion. The repository
+      # name is not passed with it -- a job output holding a secret is redacted
+      # on the runner -- so each job reads that back for itself.
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       -
         name: Checkout
@@ -65,7 +72,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push master as latest
+        # Still master's own step, and still an unconditional push: the
+        # dependabot exclusion below belongs to branch pushes, where the run
+        # reads Dependabot secrets and cannot log in, and putting it here would
+        # leave a master push made by that actor building an image the jobs
+        # below then went looking for.
+        #
+        # What changed is the tags. This used to write the tag users pull,
+        # straight out of buildx; now it pushes docker_meta's -- on master the
+        # branch name and "sha-<commit>" -- and "Publish latest" below moves
+        # latest onto the digest afterwards, once the image has been pulled
+        # back and tested. "latest" is not among these tags and is never
+        # written here ("latest=false" in the flavor above).
+        name: Build and push master
+        id: build
         if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v7
         with:
@@ -73,7 +93,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: ${{ steps.reponame.outputs.DOCKER_REPO }}:latest
+          tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -140,7 +160,8 @@ jobs:
         # pull" on the architecture that lost it fails or fetches something
         # else. The list is the only place all three are visible at once, and
         # imagetools reads it straight from the registry, so this costs a
-        # request and runs before anything is pulled.
+        # request and runs before anything is pulled -- and before latest is
+        # made to point at any of it.
         #
         # "linux/arm64", not the "linux/arm64/v8" the build asks for: v8 is
         # arm64's default variant and buildx drops it when it writes the
@@ -152,7 +173,7 @@ jobs:
         # "unknown/unknown" and are not architectures. Keep the list in step
         # with the "platforms:" above.
         env:
-          TAG: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+          TAG: "${{ steps.reponame.outputs.DOCKER_REPO }}@${{ needs.docker.outputs.digest }}"
         run: |
           expected="linux/amd64 linux/arm/v7 linux/arm64"
           published=$(docker buildx imagetools inspect --raw "${TAG}" |
@@ -166,12 +187,13 @@ jobs:
           fi
 
       - name: Pull the published image
-        # By tag and without a platform, which is what a user's docker does:
-        # the daemon picks the entry of the manifest list that matches this
-        # runner, and an entry that is missing or mislabelled fails here rather
-        # than in a test. A master run that publishes while this one is pulling
-        # would leave this testing the newer image, which its own run tests too.
-        run: docker pull "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+        # From the registry and without a platform, which is what a user's
+        # docker does: the daemon picks the entry of the manifest list that
+        # matches this runner, and an entry that is missing or mislabelled
+        # fails here rather than in a test. By digest rather than by tag: this
+        # is the image this run pushed, not whatever a master run finishing
+        # alongside it has since put under the same name.
+        run: docker pull "${{ steps.reponame.outputs.DOCKER_REPO }}@${{ needs.docker.outputs.digest }}"
 
       - name: Setup python
         uses: actions/setup-python@v7
@@ -192,7 +214,7 @@ jobs:
         # workflow, and this job's own verdict is the signal.
         timeout-minutes: 10
         env:
-          POSTFIX_RELAY_IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+          POSTFIX_RELAY_IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}@${{ needs.docker.outputs.digest }}"
           # This image is the runner's own architecture, which the fixture
           # otherwise refuses for looking like a stale local build.
           POSTFIX_RELAY_IMAGE_PUBLISHED: "1"
@@ -227,7 +249,7 @@ jobs:
           DOCKER_REPO: "${{ secrets.DOCKER_REPO }}"
 
       - name: Pull the published image
-        run: docker pull "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+        run: docker pull "${{ steps.reponame.outputs.DOCKER_REPO }}@${{ needs.docker.outputs.digest }}"
 
       - name: Setup python
         uses: actions/setup-python@v7
@@ -241,7 +263,57 @@ jobs:
       - name: Run the smoke tests
         timeout-minutes: 10
         env:
-          POSTFIX_RELAY_IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+          POSTFIX_RELAY_IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}@${{ needs.docker.outputs.digest }}"
           POSTFIX_RELAY_IMAGE_PUBLISHED: "1"
           POSTFIX_RELAY_ARCH: "arm64"
         run: pytest -m smoke
+
+  promote:
+    name: "Publish latest"
+    # The tag users pull, written only now. Until this job runs, what the build
+    # pushed is reachable under its "sha-" tag and its digest and nothing else,
+    # so latest still names the last image that got this far. It moves once the
+    # image behind that digest has been pulled back from the registry on both
+    # runner architectures and has started, reported healthy and relayed a
+    # whole message on each -- which is the difference between the suite
+    # gating what merges and gating what ships. (issue #272)
+    #
+    # It cannot make the publication conditional on the whole suite: that runs
+    # in test.yml, and a job cannot wait on another workflow. What it does gate
+    # on is the four smoke tests, run against the artefact itself rather than a
+    # local build of the same tree.
+    needs: [docker, verify_published_amd64, verify_published_arm64]
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      -
+        name: Helper for custom repo name
+        id: reponame
+        run: |
+          if [ "${DOCKER_REPO}" != "" ]; then
+            echo "DOCKER_REPO=${DOCKER_REPO}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "DOCKER_REPO=${{ github.repository }}" >> "${GITHUB_OUTPUT}"
+          fi
+        env:
+          DOCKER_REPO: "${{ secrets.DOCKER_REPO }}"
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Point latest at the image that was verified
+        # imagetools copies the manifest list rather than building or pushing
+        # anything again: latest ends up on the same digest, with the same three
+        # architectures and the same provenance attestations under it. Verified
+        # with "--dry-run" against the published image, which returned the index
+        # entry for entry.
+        run: |
+          docker buildx imagetools create -t "${REPO}:latest" "${REPO}@${DIGEST}"
+          echo "latest -> ${DIGEST}"
+        env:
+          REPO: "${{ steps.reponame.outputs.DOCKER_REPO }}"
+          DIGEST: "${{ needs.docker.outputs.digest }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,9 +10,9 @@
 #
 # Required checks are matched by job name, not by workflow name. The names
 # that exist are "Build Image", "Pytest", "Pytest (arm64)",
-# "Pytest (arm/v7, emulated)", "Event File", "Test Results", "ShellCheck" and
-# "Verify Published Image (amd64)" / "(arm64)"; "ci", "test" and "lint" are
-# workflows and never report a check of their own.
+# "Pytest (arm/v7, emulated)", "Event File", "Test Results", "ShellCheck",
+# "Verify Published Image (amd64)" / "(arm64)" and "Publish latest"; "ci",
+# "test" and "lint" are workflows and never report a check of their own.
 #
 # "Pytest (arm/v7, emulated)" runs on every pull request since #273, and is
 # still not in the required list: its verdict comes from an emulator, where a
@@ -20,9 +20,9 @@
 # rather than blocking a merge. Requiring it means adding it to
 # .github/rulesets/master.json and importing that.
 #
-# The two "Verify Published Image" jobs are not candidates either, and for a
-# firmer reason: they check the image a push to master published, so they never
-# run on a pull request at all.
+# The two "Verify Published Image" jobs are not candidates either, nor is
+# "Publish latest", and for a firmer reason: they check -- and then tag -- the
+# image a push to master published, so they never run on a pull request at all.
 
 name: Dependabot auto-merge
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ why merge commits name someone else's namespace.
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
 | `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `ruleset`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`, `upgrade`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
-| `.github/workflows/ci.yml` | `name: ci`. Three jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls the tag that was just pushed and runs `pytest -m smoke` against it; the amd64 one first asserts the published manifest lists the three platforms the build asks for. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. |
+| `.github/workflows/ci.yml` | `name: ci`. Four jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request, and the tags it pushes are docker_meta's for every ref — never `latest`. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls by digest the image that was just pushed and runs `pytest -m smoke` against it; the amd64 one first asserts the published manifest lists the three platforms the build asks for. `promote`, displayed as **Publish latest**: `master` only, `needs` all three, and points `latest` at that digest with `imagetools create`. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
@@ -262,11 +262,15 @@ display `name:`, so on an ordinary pull request it appears as a skipped
 
 **Verify Published Image (amd64)** and **(arm64)** do not run on a pull
 request: they are `needs: docker` and `master` only, because what they check is
-the publication the **Build Image** step makes there. Each pulls that tag the
-way a user would and runs `pytest -m smoke` against it — the only check in the
-tree that looks at the artefact on the registry rather than at one built from
-the tree. Nothing is rolled back when one fails; the tag is already out, and
-the check is what says so. (issue #266) The amd64 one carries one step the
+the publication **Build Image** makes there. Each pulls that image from the
+registry the way a user would and runs `pytest -m smoke` against it — the only
+checks in the tree that look at the artefact on the registry rather than at one
+built from the tree. (issue #266) They pull it by *digest*, not by tag, and
+that is the whole of the arrangement below: what the build pushes is reachable
+under `sha-<commit>` and its digest, `latest` is not written by the build at
+all, and **Publish latest** — a fourth job, `needs` on all three — moves the
+tag onto that digest afterwards. So a failure here is no longer a report on an
+image users are already pulling: the tag stays where it was. (issue #272) The amd64 one carries one step the
 other does not: each job pulls the entry of the manifest list matching its own
 runner, so a missing or mislabelled entry would leave both green while the
 architecture that lost it fails to pull at all — that step reads the list
@@ -300,9 +304,10 @@ Notes a contributor will hit:
   emulator, where a QEMU artefact reads like a real failure, so it reports and a
   person looks rather than blocking a merge. Requiring it is a separate decision,
   and `.github/rulesets/master.json` is where it would be recorded. And the two
-  **Verify Published Image** jobs have nothing to report on a branch at all:
-  what they check is the image a push to `master` published, so on a pull
-  request they are skipped by the `if:` that keeps them off it.
+  **Verify Published Image** jobs, and **Publish latest** with them, have
+  nothing to report on a branch at all: what they check, and what one of them
+  then tags, is the image a push to `master` published, so on a pull request
+  they are skipped by the `if:` that keeps them off it.
 - **The ruleset carries that one rule and no bypass actors.**
   `strict_required_status_checks_policy` is false, so a branch does not have to
   be brought up to date with `master` before it merges — with dependabot

--- a/README.md
+++ b/README.md
@@ -818,16 +818,17 @@ and has no `postsrsd`. That runs on every pull request, like the two native
 runs. Emulation is slow enough that the rest is not worth its minutes, and
 every wait in the suite is measured against a native run.
 
-All of that tests an image built from the tree. Every push to `master` also
-publishes `latest`, and what reaches the registry is built by buildx rather
-than by the daemon the suite uses, so a check after the push pulls that tag on
-`amd64` and on `arm64` -- the way anyone else pulls it -- and runs the same
-smoke tests against it. It also reads the manifest that tag points at, and
-fails if it does not list all three architectures that were built: each half
-of the check pulls the entry for its own architecture, so the one with no
-runner is only visible there. It is the only check that looks at the image
-users actually pull. Nothing is rolled back when it fails: the tag is out by then,
-and the check is what says so.
+All of that tests an image built from the tree. What reaches the registry is
+built by buildx rather than by the daemon the suite uses, so a push to `master`
+publishes the image under its commit before it publishes it under `latest`:
+the pushed image is pulled back on `amd64` and on `arm64` -- the way anyone
+else pulls it -- and the same smoke tests are run against it. Its manifest is
+read too, and the push fails if it does not list all three architectures that
+were built: each half of the check pulls the entry for its own architecture,
+so the one with no runner is only visible there. Only then is `latest` moved
+onto that image. It is the only check that looks at the image users actually
+pull, and it runs before they can pull it: an image that does not come up
+leaves `latest` where it was.
 
 | File | What it covers |
 | --- | --- |


### PR DESCRIPTION
Closes #272.

## What was wrong

`ci.yml` declares no `needs:`, so on a push to `master` **Build Image** pushed le tag que les gens tirent dès que buildx réussissait, pendant que la suite tournait en parallèle dans `test.yml`. Les tests gardaient ce qui fusionne, pas ce qui part: un changement fusionné vert puis cassé sur `master` était publié quand même, et les deux jobs **Verify Published Image** de #266 ne pouvaient que le constater après coup.

## What this does

| Before | After |
| --- | --- |
| build pushes `latest` | build pushes docker_meta's tags -- on `master`, the branch name and `sha-<commit>` -- and exports the digest as a job output |
| verify jobs pull `:latest` | verify jobs pull `@sha256:...`: the same artefact from the same registry, named so a master run finishing alongside cannot swap it |
| -- | **Publish latest**, a fourth job, points the tag at that digest with `imagetools create` once both have passed |

An image that does not come up now leaves `latest` where it was.

## What it does not do

Gate on the **whole suite**. That runs in `test.yml`, and a job cannot wait on another workflow. What gates the tag is the four smoke tests -- it starts, reports healthy, relays a whole message, answers for `postsrsd` -- run against the artefact itself. Gating on `test.yml` as well would need the `workflow_run` plumbing #272 also describes, and it would cost a second build; this shape costs no extra build at all.

## One thing worth reviewing closely

Master's build step keeps its **unconditional** push rather than taking the branch step's dependabot exclusion. The two were briefly one step here, which was tidier and wrong: that exclusion exists for a branch push whose run reads Dependabot secrets and cannot log in, and applying it to master would leave such a push building an image the jobs below then went looking for.

## Visible consequence

`master` pushes now leave `master` and `sha-<commit>` tags on the registry, where before they left only `latest`. Branch pushes already published `sha-` tags, so the shape is not new -- but every master image is now reachable, and roll-back-able, by an immutable tag.

## Verified

- `imagetools create --dry-run -t <repo>:promoted <repo>@<digest>` against the published image returns the index **entry for entry** -- the same three architectures and the same three provenance attestations -- so promoting copies the manifest rather than rebuilding it;
- the manifest step and `docker pull` both take a digest reference, and `pytest -m smoke` with `POSTFIX_RELAY_IMAGE=<repo>@sha256:...` is **4 passed**, so the fixture and testcontainers take one too;
- `pytest` -> **244 passed, 2 skipped**; `tests/test_ruleset.py`, qui lit chaque fichier de workflow, passe avec le nouveau job.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
