### PR TITLE
Correct what the crossing left false, and one predicate with it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,10 +751,12 @@ changing any of them.
     edited, and it is what deployments actually run. The cost is that it lags
     the tree by whatever has been merged since: SRS landed after 1.2.17, so
     the released image never wrote a secret, and the SRS test skips itself
-    saying so instead of passing. It decides that by reading the released
-    image's own `run` for `POSTSRSD_`, not by comparing version numbers, so it
-    starts running of its own accord the first time the anchor moves past the
-    release that adds the feature. And `upgrade_from_image` pulls for the
+    saying so instead of passing. It decides that by asking the released image
+    for a `postsrsd` binary, not by comparing version numbers, so it starts
+    running of its own accord the first time the anchor moves past the release
+    that adds the feature. The binary and not `POSTSRSD_` in its `run`: that
+    string is in the script on every architecture, and on armhf the branch
+    holding it is the one refusing to start for want of the package. And `upgrade_from_image` pulls for the
     platform of the image under test rather than the machine's: wherever
     `POSTFIX_RELAY_IMAGE` names an image this run did not build — a foreign
     architecture, or the published one 30 now also admits — the machine's own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ why merge commits name someone else's namespace.
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
 | `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`, `upgrade`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
-| `.github/workflows/ci.yml` | `name: ci`. Two jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls the tag that was just pushed and runs `pytest -m smoke` against it. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. |
+| `.github/workflows/ci.yml` | `name: ci`. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls the tag that was just pushed and runs `pytest -m smoke` against it. Spelled out rather than a matrix, for the reason test.yml gives — the job name is what a required status check and the auto-merge workflow match on — and for one of its own: a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
@@ -265,9 +265,11 @@ the branch. It pins the QEMU binfmt image, builds `linux/arm/v7`, and runs
 **Verify Published Image (amd64)** and **(arm64)** do not run on a pull request
 either: they are `needs: docker` and `master` only, because what they check is
 the publication the **Build Image** step makes there. Each pulls that tag the
-way a user would and runs `pytest -m smoke` against it — the only check in the
-tree that looks at the artefact on the registry rather than at one built from
-the tree. Nothing is rolled back when one fails; the tag is already out, and
+way a user would and runs `pytest -m smoke` against it — the only check that
+looks at what a push to `master` published rather than at an image built from
+the tree. It is no longer the only thing here that reaches the registry:
+`tests/test_upgrade.py` pulls a *released* tag, which is a different question
+(see 33). Nothing is rolled back when one fails; the tag is already out, and
 the check is what says so. (issue #266)
 
 Notes a contributor will hit:

--- a/README.md
+++ b/README.md
@@ -783,7 +783,8 @@ postfix setting.
 
 Set `POSTFIX_RELAY_IMAGE` to run against an image that is already built
 instead of building one. It is taken only for an architecture this machine
-cannot build, which is the whole reason it exists: building from the
+cannot build, or for the image that was published — between them the whole
+reason it exists: building from the
 `Dockerfile` is what makes the suite test the tree it is run in, and naming an
 image it could have built is refused rather than quietly testing whatever was
 left in the image store. Building one needs the emulators registered and a
@@ -821,11 +822,11 @@ against a native run.
 
 All of that tests an image built from the tree. Every push to `master` also
 publishes `latest`, and what reaches the registry is built by buildx rather
-than by the daemon the suite uses, so a check after the push pulls that tag on
-`amd64` and on `arm64` -- the way anyone else pulls it -- and runs the same
-smoke tests against it. It is the only check that looks at the image users
-actually pull. Nothing is rolled back when it fails: the tag is out by then,
-and the check is what says so.
+than by the daemon the suite uses, so after the push that tag is pulled on
+`amd64` and on `arm64` -- the way anyone else pulls it -- and the same smoke
+tests are run against it, one job per architecture. They are what looks at the
+image a push to `master` just published. Nothing is rolled back when one
+fails: the tag is out by then, and the check is what says so.
 
 | File | What it covers |
 | --- | --- |

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,9 +19,9 @@ addopts = -n auto --dist loadfile --maxprocesses 4
 # not build, where the whole run is not what there is left to learn: the
 # container starts, it reports healthy, a whole message goes in one end and
 # comes out the other, and the postsrsd the arm/v7 image does not have is
-# answered for both ways round. Two jobs run them -- the emulated arm/v7 one in
-# .github/workflows/test.yml, where the whole suite would be too slow, and the
-# ones in .github/workflows/ci.yml that pull the image a push to master
+# answered for both ways round. They are run by the emulated arm/v7 job in
+# .github/workflows/test.yml, where the whole suite would be too slow, and by
+# the jobs in .github/workflows/ci.yml that pull the image a push to master
 # published, where the suite has already run against this same commit.
 markers =
     smoke: enough to say an image the suite did not build starts and relays

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -3,7 +3,8 @@
 Pulling a newer image replaces the whole filesystem, so what an upgrade
 actually asks is whether the state left behind is still readable: the queue
 and the DKIM keys in the two volumes, and the SRS secret in the file the
-README says to mount. The Upgrading section promises all three survive.
+README says to mount. The Upgrading section promises the two volumes survive;
+the SRS section promises the same of the secret, to whoever mounted it.
 
 Everywhere else in the suite the container that writes that state and the one
 that reads it are the same build, which is a restart rather than an upgrade
@@ -91,12 +92,19 @@ def older_image_that_rewrites(upgrade_from_image):
     image rather than written as a version to compare against: it starts
     running of its own accord the first time the anchor moves to a release
     that has the feature.
-    """
-    knows_srs = image_run(upgrade_from_image, [
-        "bash", "-c", "grep -q POSTSRSD_ /root/run && echo yes || echo no"])
 
-    if 'yes' not in knows_srs:
-        pytest.skip(f"{upgrade_from_image} has no SRS, so it left no secret to reuse")
+    The question is whether the image can rewrite, so it is put to the binary
+    and not to the entrypoint's text. "run" names POSTSRSD_ on every
+    architecture, armhf included, where the branch that names it is the one
+    refusing to start because Debian builds no postsrsd there -- so grepping
+    the script would answer "yes" for the one image that most certainly wrote
+    no secret. "command -v postsrsd" is the same question "run" itself asks.
+    """
+    rewrites = image_run(upgrade_from_image, [
+        "bash", "-c", "command -v postsrsd > /dev/null && echo yes || echo no"])
+
+    if 'yes' not in rewrites:
+        pytest.skip(f"{upgrade_from_image} has no postsrsd, so it left no secret to reuse")
 
     return upgrade_from_image
 


### PR DESCRIPTION
Closes #295 and #296— please fill in the two numbers.

Two commits, one per issue.

### `c20e839` — what the crossing left false

Five pull requests merged inside half an hour. Two counts (`CLAUDE.md`'s `ci.yml` row saying "Two jobs." above three, `pytest.ini` saying "Two jobs run them" above three) are **dropped rather than raised**, per the rule CLAUDE.md states about itself and `5ea6518` applied: both sentences already enumerate what they were counting.

Two exclusivity claims — "the only check in the tree that looks at the artefact on the registry" and "the only check that looks at the image users actually pull" — are narrowed to what they are actually about, now that `tests/test_upgrade.py` pulls a released tag inside the ordinary **Pytest** jobs. And one reason attributed to `test.yml` is given back to `ci.yml`, which is whose it is.

The README's "taken only for an architecture this machine cannot build" gets the published-image case #281 added everywhere else.

No workflow, script or test is touched by this commit.

### `f0f12c8` — ask for the binary, not for a string

The SRS skip predicate grepped the older image's `run` for `POSTSRSD_`. That string is in the script on every architecture, and on armhf the branch holding it is the one refusing to start for want of the package — so the grep answers "yes" for the one image that certainly wrote no secret. `command -v postsrsd` is the question `run` itself asks. The module docstring's attribution of the SRS promise to the *Upgrading* section is corrected at the same time, and invariant 33 follows the predicate.

### Verification

- `pytest` → **242 passed, 2 skipped**, 2m53s.
- `pytest tests/test_upgrade.py` → 2 passed, 1 skipped, the skip now reading `mwader/postfix-relay:1.2.17 has no postsrsd`.
- With the anchor temporarily pointed at `mwader/postfix-relay:latest`, which has the binary → **3 passed**: the new predicate still admits what it should rather than merely skipping everything. The anchor was put back afterwards.
- Every item was re-derived from the files before being changed, with a second reader reproducing it independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qse8Hgqa967LcWqzL2BJZs