### PR TITLE
Ignore the junit directory the documented pytest run writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 __pycache__/
+junit/


### PR DESCRIPTION
CLAUDE.md's Commands section offers

```
pytest --junitxml=junit/test-results.xml     # exactly what CI runs
```

as the invocation to reach for when reproducing a CI run locally, and running it leaves `junit/` untracked in the working tree. Nothing ignores it: `.gitignore` carries `.vscode/` and `__pycache__/` and stops there.

pytest's own cache does not have this problem, and why is worth saying, because it is what explains this being the only leak: `.pytest_cache/` ships a `.gitignore` of its own containing `*`, which pytest writes when it creates the directory. `--junitxml` writes to a path the caller chose instead, so there is nothing for pytest to self-ignore and the repository has to.

CI never sees it -- a runner checks out fresh, uploads the file as an artifact and is thrown away -- so this only ever costs a contributor, and it costs them in the way an ignore file exists to prevent: a `git add -A` after a local run commits one machine's test results.

Verified in the tree: after creating `junit/test-results.xml`, `git status --porcelain --untracked-files=all` reports nothing but the `.gitignore` edit itself, and `git check-ignore -v junit/test-results.xml` answers `.gitignore:3:junit/`. The suite on this branch is 244 passed, 2 skipped.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU