### PR TITLE
Name the root process that does read what a client sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,13 +447,23 @@ actually handles mail is not root:
 | Process | Runs as |
 | --- | --- |
 | the start-up script, `master`, `rsyslogd` | `root` |
+| `saslauthd`, when `SASL_Passwds` is set | `root` |
 | `smtpd`, `cleanup`, `qmgr`, `smtp`, the rest of postfix | `postfix`, chrooted into `/var/spool/postfix` |
 | `opendkim` | `opendkim` |
 | `postsrsd` | `postsrsd`, chrooted into `/var/lib/postsrsd` |
 
-The root processes supervise and log; they do not parse untrusted input. Most
-of what docker grants the container by default is therefore unused and can be
-taken away:
+As the relay ships, the root processes supervise and log; they do not parse
+untrusted input. Setting `SASL_Passwds` adds one that does: `saslauthd` runs as
+root and checks the username and password an SMTP client sent, through PAM.
+That is what it is for, and it is why the directory holding its socket is
+created `root:sasl` mode `710` rather than left at the world-writable mode
+`saslauthd` gives the socket itself -- an unauthenticated password check
+reachable by every uid in the container would be an oracle for guessing at the
+passwords. Nothing to configure, but worth knowing before deciding what a
+relay of yours may do.
+
+Either way, most of what docker grants the container by default is unused and
+can be taken away:
 
 ```
 cap_drop:

--- a/tests/test_sasl.py
+++ b/tests/test_sasl.py
@@ -256,6 +256,24 @@ def test_the_saslauthd_socket_is_restricted_to_the_sasl_group(authenticated_rela
         "stat -c %U:%G:%a /var/spool/postfix/var/run/saslauthd").strip() == 'root:sasl:710'
 
 
+def test_saslauthd_checks_passwords_as_root(authenticated_relay):
+    """The README's "What runs as root" table has a row for this, and the
+    capability advice under that table rests on which processes touch what a
+    client sent. Every other root process in the container supervises or logs;
+    this one reads a username and password off the network and checks them,
+    which is what makes the mode on the directory above the access control
+    rather than a detail. Asserted rather than described so that a future
+    change dropping it to its own user is noticed here, and the README with
+    it. (issue #294)
+    """
+    processes = container_exec(authenticated_relay, ["ps", "-eo", "uid,comm", "--no-headers"])
+    uids = [line.split()[0] for line in processes.splitlines()
+            if line.split()[1:2] == ['saslauthd']]
+
+    assert uids, f"saslauthd is not running: {processes}"
+    assert set(uids) == {'0'}, f"saslauthd runs as {sorted(set(uids))}, not root"
+
+
 def test_the_generated_pam_profile_reads_the_password_file(authenticated_relay):
     """SASL_Passwds names the file, and PAM is what actually opens it."""
     profile = container_exec(authenticated_relay, ["cat", "/etc/pam.d/smtp"])


### PR DESCRIPTION
Closes #294.

## The claim that was false

`README.md`'s *What runs as root* table listed the start-up script, `master` and `rsyslogd`, and the sentence under it said:

> The root processes supervise and log; they do not parse untrusted input.

True of the relay as shipped. False as soon as `SASL_Passwds` is set: `run` starts `saslauthd`, which runs as uid 0 et vérifie un identifiant et un mot de passe arrivés par SMTP, via PAM.

Measured on the built image with `SASL_Passwds` set:

```
      5 root  0  saslauthd
      1 root  0  run
      1 root  0  rsyslogd
      1 root  0  master
      1 postfix 101 smtpd     (and the rest of postfix)
```

## Why it matters beyond tidiness

That section exists to justify the capability set it then recommends dropping. A reader deciding what a relay of theirs may do was being told no root process touches attacker-controlled bytes. On an authenticating relay, one does.

## What changed

- a row for `saslauthd` -- root, only when `SASL_Passwds` is set;
- the sentence **qualified rather than rewritten**: as shipped it still holds, and the qualification names what already protects that daemon -- the mux directory created `root:sasl` mode `710`, against the world-writable mode `saslauthd` gives the socket itself. That was documented as an invariant and had no reason a README reader could see.

## And a test

`tests/test_sasl.py` already pinned the mode on that directory; who runs the process behind it was not pinned at all, so a change dropping `saslauthd` to its own user would have left the README saying something untrue with nothing to notice. `test_saslauthd_checks_passwords_as_root` asserts it now.

## Verified

- `pytest` -> **245 passed, 2 skipped**, against 244 before;
- `ruff check --no-cache --select F tests` clean;
- the process table above comes from a container started with `SASL_Passwds` and a mounted passwd file, not from reading `run`.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
