### PR TITLE
Scan the published image for fixable vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
     tags:
       - '*'
   pull_request:
+  # The remediation lever for a scan.yml finding, and the only way to move the
+  # image's package set without editing the Dockerfile.
+  #
+  # The apt install below is unversioned, so a build resolves every package to
+  # whatever the archive has that day -- but only when it actually runs. With
+  # cache-from/cache-to below, that layer is a cache hit until the FROM line
+  # changes, so merging anything else and rebuilding master republishes the
+  # same packages. Ticking this discards the cache, which re-resolves the
+  # install closure against the archive and picks up a Debian fix in minutes
+  # instead of waiting two to three weeks for the next trixie-<date>-slim tag.
+  workflow_dispatch:
+    inputs:
+      no-cache:
+        description: "Rebuild without the layer cache"
+        type: boolean
+        default: false
 
 # A new push makes the images an in-flight run would produce obsolete, except
 # on master where the run publishes latest.
@@ -77,6 +93,9 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Null on every trigger but workflow_dispatch, and false is what the
+          # action wants to see then.
+          no-cache: ${{ inputs.no-cache || false }}
       -
         name: Build and push branch or test PR
         if: github.ref != 'refs/heads/master'
@@ -90,3 +109,4 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          no-cache: ${{ inputs.no-cache || false }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,6 +14,15 @@
 # "Pytest (arm/v7, emulated)" does not run on a pull request unless it is
 # labelled "test-emulated", which is nearly all of them, so it is not a
 # candidate for the required list whatever github makes of a skipped check.
+#
+# "Image Scan", from scan.yml, is not on that list either and is not a
+# candidate for it. It runs on a schedule against the published image and
+# never on a pull request, so it reports no check here at all; scan.yml's
+# header says why letting a vulnerability database decide a pull request would
+# be the wrong trade. It matters for auto-merge that it stays that way: these
+# pull requests merge themselves once the required checks pass, and a gate
+# whose verdict changes overnight for reasons unrelated to the diff would
+# block a bump on a morning when the bump is the fix.
 
 name: Dependabot auto-merge
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,218 @@
+name: scan
+
+on:
+  schedule:
+    # Daily, and deliberately not on the hour: github queues everything that
+    # asked for :00 together, and a job nobody is waiting for should not be in
+    # that queue.
+    #
+    # Daily is the cadence the thing being watched deserves. Debian ships a
+    # fix, and this image picks it up when its base tag moves -- dated
+    # trixie-*-slim tags land every two to three weeks -- so the window is
+    # weeks wide and a daily look is the cheapest thing that notices inside it.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+# Everything this does to the repository, it does by filing one issue.
+permissions:
+  contents: read
+  issues: write
+
+# Two runs must not race to file the same issue. Queue the second rather than
+# cancelling the first: the first is the one that would have opened it.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+# What this is, and what it deliberately is not.
+#
+# It scans the image people pull, on a clock, and never reports a check on a
+# pull request. That placement is the design rather than a limitation, and
+# three things settle it.
+#
+# ci.yml pushes nothing on a pull request, so a pull request has no published
+# image. A scan there would examine an artefact with no users while the one
+# with eleven million pulls went unexamined.
+#
+# A red here would never be attributable to the diff. ci.yml builds only what
+# the tree contains, so a pull request touching "run", a fixture or the README
+# cannot introduce a Debian CVE -- and its author holds no lever either, since
+# the remedy is a base image bump that dependabot.yml deliberately keeps out of
+# auto-merge. Every other gate in this tree -- ShellCheck, Pytest, Build Image
+# -- fails for something its author caused and can fix.
+#
+# And lint.yml's header already wrote the rule this follows: "An unpinned
+# linter fails somebody's unrelated pull request on the day it ships a new
+# check." A vulnerability database is that input by construction, because
+# pinning it is the same as not running this at all. So this stays off the pull
+# request path; promoting it to a required check means answering that argument
+# rather than assuming it.
+#
+# --ignore-unfixed is what makes a red mean something. Without it this reports
+# around 290 findings that Debian has assessed as not warranting a stable
+# update and nobody here can close. The largest single group of them, 68 of 287
+# rows when this was written, is perl -- in the image only so the
+# manually-invoked qshape keeps working, and executed by no relaying container.
+# With it, a red says exactly one thing: Debian shipped a fix that the
+# published image does not have.
+#
+# So this is expected to be green, and it was when it was written: trivy and
+# grype both reported zero fixable findings, and "apt-get -s full-upgrade"
+# inside the published image agreed with them. It is an alarm for a window, not
+# a backlog to work through.
+
+jobs:
+  trivy:
+    name: "Image Scan"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      # Pinned and checksummed, and nothing bumps it, the way lint.yml installs
+      # shellcheck -- and here the reason is not hypothetical. The
+      # aquasecurity/trivy-action wrapper was compromised on 2026-03-19, when
+      # 76 of its 77 version tags were force-pushed to a credential stealer.
+      # Pinning that action by tag would not have helped, and pinning it by
+      # commit would tie this to a wrapper breached twice in a month. The job
+      # needs no checkout, no buildx and no QEMU, so skipping the dependency
+      # costs one curl.
+      #
+      # A binary that never moves costs this job much less than it costs a
+      # linter: the database is fetched fresh on every run and is what carries
+      # the signal.
+      #
+      # sha256 is the one from trivy_0.74.0_checksums.txt for the Linux-64bit
+      # tarball.
+      TRIVY_VERSION: v0.74.0
+      TRIVY_SHA256: 2ae6fe3ee734b7fdf11335663e18c75ea12dccc76062f09f164a3b0f8be4371a
+      ISSUE_TITLE: "Fixable vulnerabilities in the published image"
+    steps:
+      - name: Helper for custom repo name
+        # The same resolution ci.yml uses to decide what to push. It has to
+        # agree with it: the point is to scan what was published, so the name
+        # cannot be written here independently and drift.
+        id: reponame
+        run: |
+          if [ "${DOCKER_REPO}" != "" ]; then
+            echo "DOCKER_REPO=${DOCKER_REPO}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "DOCKER_REPO=${{ github.repository }}" >> "${GITHUB_OUTPUT}"
+          fi
+        env:
+          DOCKER_REPO: "${{ secrets.DOCKER_REPO }}"
+
+      - name: Install trivy
+        # Into RUNNER_TEMP. Nothing is checked out in this job at all -- trivy
+        # pulls the published manifest itself, so there is no build context to
+        # keep it out of.
+        run: |
+          set -eu
+          version="${TRIVY_VERSION#v}"
+          url="https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/trivy_${version}_Linux-64bit.tar.gz"
+          curl -fsSL -o "${RUNNER_TEMP}/trivy.tar.gz" "$url"
+          echo "${TRIVY_SHA256}  ${RUNNER_TEMP}/trivy.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/trivy"
+          tar -xzf "${RUNNER_TEMP}/trivy.tar.gz" -C "${RUNNER_TEMP}/trivy"
+          echo "${RUNNER_TEMP}/trivy" >> "${GITHUB_PATH}"
+
+      - name: Scan the published image
+        # linux/amd64, which is what the runner is. The three published
+        # platforms were measured to carry the same findings: every package the
+        # Dockerfile names resolves to the same Debian version on all three,
+        # because Debian keeps one source version across release
+        # architectures, and the one package that differs -- postsrsd, absent
+        # on armhf -- has none. That is an assumption about Debian rather than
+        # something this job verifies, so it is written down here.
+        #
+        # --exit-code 0 is deliberate, and the reason is the next step. Trivy
+        # exits non-zero both when it finds something and when it could not do
+        # its job, and those must not be confused: an unreachable database
+        # filed as a vulnerability would be worse than no scan. So findings are
+        # counted out of the report instead, and a non-zero exit from here can
+        # only mean trivy failed -- which skips every step below and fails the
+        # run, so it is an email rather than a wrong issue.
+        id: scan
+        run: |
+          set -eu
+          trivy --version
+          trivy image \
+            --scanners vuln \
+            --ignore-unfixed \
+            --severity HIGH,CRITICAL \
+            --format json \
+            --output "${RUNNER_TEMP}/trivy.json" \
+            --timeout 10m \
+            --exit-code 0 \
+            "${IMAGE}"
+          count=$(jq '[.Results[]?.Vulnerabilities[]?] | length' "${RUNNER_TEMP}/trivy.json")
+          echo "count=${count}" >> "${GITHUB_OUTPUT}"
+          echo "${count} finding(s) with a fix available in ${IMAGE}"
+          trivy convert --format table "${RUNNER_TEMP}/trivy.json" \
+            | tee "${RUNNER_TEMP}/trivy.txt"
+        env:
+          IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+
+      - name: Open the finding issue
+        # One issue, held open for as long as the finding stands. A daily cron
+        # that commented every morning would teach everyone to filter it, so a
+        # run that finds the issue already open says nothing and leaves it be.
+        if: steps.scan.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -eu
+          # Matched on the title rather than through the search index, which
+          # lags by enough that a daily job would file a second one.
+          existing=$(gh issue list --state open --limit 100 --json number,title \
+            --jq '[.[] | select(.title == env.ISSUE_TITLE) | .number] | first // empty')
+          if [ -n "$existing" ] ; then
+            echo "Issue #${existing} is already open, leaving it alone."
+            exit 0
+          fi
+          {
+            echo "\`trivy image --ignore-unfixed --severity HIGH,CRITICAL\` found"
+            echo "vulnerabilities in \`${IMAGE}\` that Debian has already shipped a fix for."
+            echo
+            echo "The remedy is a build that re-resolves the packages: merge the pending"
+            echo "base image bump if there is one, or run the **ci** workflow from the"
+            echo "Actions tab with **Rebuild without the layer cache** ticked, which"
+            echo "re-resolves every package against the archive without waiting for the"
+            echo "next \`trixie-<date>-slim\` tag."
+            echo
+            echo "This issue is closed automatically once the scan comes back clean."
+            echo
+            echo "[Scan run](${RUN_URL})"
+            echo
+            echo '```'
+            head -c 50000 "${RUNNER_TEMP}/trivy.txt"
+            echo '```'
+          } > "${RUNNER_TEMP}/issue.md"
+          gh issue create --title "${ISSUE_TITLE}" --body-file "${RUNNER_TEMP}/issue.md"
+
+      - name: Close the finding issue
+        # The scan is clean, so whatever this job filed earlier is answered.
+        if: steps.scan.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -eu
+          existing=$(gh issue list --state open --limit 100 --json number,title \
+            --jq '[.[] | select(.title == env.ISSUE_TITLE) | .number] | first // empty')
+          if [ -z "$existing" ] ; then
+            echo "Nothing open, nothing to close."
+            exit 0
+          fi
+          gh issue close "$existing" --comment \
+            "\`${IMAGE}\` no longer has a vulnerability with a fix available. [Scan run](${RUN_URL})"
+
+      - name: Fail the run
+        # Last, so the issue is filed before the job goes red. The email github
+        # sends for a failed scheduled run is the immediate signal; the issue
+        # is the one that is still there next week.
+        if: steps.scan.outputs.count != '0'
+        run: |
+          echo "${{ steps.scan.outputs.count }} finding(s) with a fix available."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,11 @@ why merge commits name someone else's namespace.
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
 | `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
-| `.github/workflows/ci.yml` | `name: ci`. One job, `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. |
+| `.github/workflows/ci.yml` | `name: ci`. One job, `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request. Also `workflow_dispatch` with one boolean input, `no-cache`, wired into both build steps — the remediation lever for an **Image Scan** finding. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. One job, `shellcheck`, displayed as **ShellCheck**: downloads a pinned, checksummed shellcheck and runs `shellcheck -S error run healthcheck`. The only linter in the tree, and the only threshold the two scripts pass. |
+| `.github/workflows/scan.yml` | `name: scan`. One job, `trivy`, displayed as **Image Scan**: on a daily `schedule:` and on `workflow_dispatch`, downloads a pinned, checksummed trivy and scans the *published* image at `--ignore-unfixed --severity HIGH,CRITICAL`. Never runs on a pull request. Files one issue when it finds something and closes it when it stops, which is the only thing in the tree that writes to the tracker. |
 | `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment is also where the check names are recorded. |
 | `.github/dependabot.yml` | `github-actions` weekly (grouped minor/patch and major), `docker` daily for the base image, `pip` weekly for the pinned test dependencies in `tests/`, `docker` weekly on `/tests` for the mailpit anchor. |
 
@@ -251,6 +252,11 @@ from the event that started the run, so it takes effect on the *next* push to
 the branch. It pins the QEMU binfmt image, builds `linux/arm/v7`, and runs
 `pytest -m smoke -n0`.
 
+An eighth, **Image Scan** from `scan.yml`, has no `pull_request` trigger at all
+and so never reports a check on one. That is the point of it rather than an
+omission — see invariant 33 — and it is why nothing above changes for a
+contributor.
+
 Notes a contributor will hit:
 
 - **Required checks match the job's `name:`**, never the workflow name and
@@ -268,9 +274,11 @@ Notes a contributor will hit:
   in `test-results.yml`; everything else is on a major tag, and Dependabot's
   weekly `github-actions` ecosystem bumps them. Do not "normalise" that
   exception away.
-- `ci.yml` runs on pushes to every branch and tag; `test.yml` runs on pushes to
-  `master` only, plus `pull_request` and `workflow_dispatch`. Both cancel
-  in-flight runs on any ref but `master`.
+- `ci.yml` runs on pushes to every branch and tag, plus `pull_request` and
+  `workflow_dispatch`; `test.yml` runs on pushes to `master` only, plus
+  `pull_request` and `workflow_dispatch`. Both cancel in-flight runs on any ref
+  but `master`. `scan.yml` is the only one with a `schedule:`, and the only one
+  with no `pull_request` trigger.
 - Version skew: CI pins Python 3.13, and nothing pins a Python version locally.
   The Python dependencies are pinned exactly (`tests/requirements.txt`); their
   transitive dependencies are not, and there is no lock file, so a run can
@@ -675,3 +683,42 @@ changing any of them.
     `FROM` line: a fallback to a version written in the module would work
     perfectly and restore exactly the invisible constant this replaces.
     (issue #235)
+
+33. **`scan.yml` has no `pull_request` trigger, uses no third-party action, and
+    passes `--ignore-unfixed`. All three look like something left out.**
+    The scan runs on a clock against the *published* image, because `ci.yml`
+    pushes nothing on a pull request — a scan there would examine an artifact
+    with no users while the one with eleven million pulls went unexamined — and
+    because a red would never be attributable to the diff: `ci.yml` builds only
+    what the tree contains, so a pull request touching `run`, a fixture or the
+    README cannot introduce a Debian CVE, and its author holds no lever, the
+    remedy being a base bump `dependabot.yml` deliberately keeps out of
+    auto-merge. `lint.yml`'s header already states the rule this follows —
+    an unpinnable input must not fail somebody's unrelated pull request — and a
+    vulnerability database is that input by construction, since pinning it is
+    the same as not running the scan. Promoting this to a required check means
+    answering that, not assuming it.
+    Trivy is a checksummed release download rather than
+    `aquasecurity/trivy-action` because that wrapper was compromised on
+    2026-03-19, when 76 of its 77 version tags were force-pushed to a
+    credential stealer — a tag pin would not have helped, and the job needs no
+    checkout, no buildx and no QEMU, so it costs one `curl` to skip the
+    dependency entirely. Nothing bumps that pin, and unusually little is lost
+    by that: the database is fetched fresh on every run and is what carries the
+    signal.
+    `--ignore-unfixed` is what makes the result mean anything. Without it the
+    job reports around 290 findings Debian has assessed as not warranting a
+    stable update and nobody here can close. The largest single group of them,
+    68 of 287 rows when this was written, is perl -- in the image only so the
+    manually-invoked `qshape` keeps working (invariant 25), and executed by no
+    relaying container. With it, a red run
+    says exactly one thing: Debian shipped a fix the published image lacks.
+    It is expected to be green — it was when it was written, `trivy` and
+    `grype` both reporting zero fixable findings and `apt-get -s full-upgrade`
+    inside the published image agreeing.
+    The `no-cache` dispatch input on `ci.yml` is the other half and does not
+    stand alone: the apt install is unversioned, so a build resolves current
+    archive versions, but `cache-from`/`cache-to` make that layer a cache hit
+    until the `FROM` line moves. Without the input, the only answer to a
+    finding is to wait two to three weeks for the next `trixie-<date>-slim`
+    tag. (issue #269)

--- a/README.md
+++ b/README.md
@@ -587,6 +587,30 @@ rather not upgrade with mail in flight, deliver what is queued and check the
 queue is empty first (see [the queue
 section](#mail-is-piling-up-and-i-want-to-know-what-the-queue-is-doing)).
 
+Pulling is also how a security fix in one of the Debian packages reaches you,
+so it is worth knowing what moves the image. There is no `apt-get upgrade` at
+start-up — a container patching itself would drift away from the image it says
+it is — and the image is instead rebuilt when its Debian base tag moves, which
+is every few weeks. A scheduled job scans the published image daily and opens
+an issue if it finds a vulnerability Debian has already shipped a fix for; if
+it is quiet, that is the state it is expected to be in. You do not have to take
+that on trust, and your risk appetite may not be ours: the image is public, so
+
+```
+trivy image mwader/postfix-relay
+grype mwader/postfix-relay
+```
+
+need no account and tell you what is in the one you are actually running. Both
+will list findings the daily job deliberately ignores, because Debian has
+assessed them as not warranting a stable update and no rebuild here can clear
+them. The largest single group of those is `perl`, which is present only so
+that [`qshape`](#mail-is-piling-up-and-i-want-to-know-what-the-queue-is-doing)
+keeps working and which a relaying container never runs. What actually handles mail —
+postfix, the TLS library, the SASL stack — is a much smaller surface, and
+[What runs as root](#what-runs-as-root-and-what-to-take-away) is where to look
+next if you want to shrink it.
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- LOGGING -->


### PR DESCRIPTION
Closes #269.

Nothing in the tree looked at what the image ships. The daily Dependabot base bump was the only thing moving a package, and dated `trixie-*-slim` tags land every two to three weeks -- so a fix Debian had already published could sit unshipped with nothing to say so.

**Two of #269's claims did not survive measurement, and both change the design.**

*"That covers CVEs which a newer base fixes, and nothing else."* Bumping `FROM` invalidates the single `RUN apt-get install` layer, re-resolving all 13 packages and their closure at current archive versions. The pinned base has 20 fixable rows, all `libssl3t64`/`openssl-provider-legacy` 3.5.6; the published image already ships 3.5.7. The build cleared them before any scanner ran.

*It would produce a list.* It finds nothing today: trivy 287 findings, **0** with a fix; grype 277, 0 fixed; and `apt-get -s full-upgrade` inside the published image agrees -- `0 upgraded`.

**Why it is not a pull request gate.** The issue's title says *published image*, its body says *built image in CI*; this takes the title. `ci.yml` publishes nothing on a pull request, so a scan there examines an artefact with no users while the one with eleven million pulls goes unexamined. A red would never be attributable to the diff -- `ci.yml` builds only what the tree contains -- and its author holds no lever, the remedy being a base bump `dependabot.yml` keeps out of auto-merge. `lint.yml`'s header already wrote the rule: an unpinnable input must not fail somebody's unrelated pull request, and a vulnerability database is that input by construction.

So **nothing about what blocks a contributor changes**: `scan.yml` has no `pull_request` trigger, and the ruleset keeps its four required checks.

**What is here**

- `.github/workflows/scan.yml` (new) -- job `trivy`, check **Image Scan**. Daily `schedule:` + `workflow_dispatch` against the published image at `--ignore-unfixed --severity HIGH,CRITICAL`. No checkout, no buildx, no secrets. Files one issue while a finding stands, closes it when clean.
- `ci.yml` -- `workflow_dispatch` with a `no-cache` input, the remediation lever: the apt install is unversioned, but `cache-from`/`cache-to` freeze that layer until `FROM` moves.
- `dependabot-auto-merge.yml`, `CLAUDE.md` (invariant 34), `README.md` -- documentation.

Three deliberate decisions, each argued in the file: trivy is a **checksummed release download, not `aquasecurity/trivy-action`** (that wrapper was compromised 2026-03-19, 76 of 77 tags force-pushed to a credential stealer, so a tag pin would not have helped); **`--ignore-unfixed`** is what makes a red mean something; and an **operational failure is told apart from a finding** (JSON at `--exit-code 0`, findings counted from the report) so an unreachable database is never filed as a vulnerability.

**Verification.** Scan against `mwader/postfix-relay:latest`: 0 findings, exit 0. Detecting path exercised against the pinned base, which does lag: 2 findings rendering correctly. `TRIVY_SHA256` checked against the published checksums file. `actionlint` + shellcheck 0.11.0 clean on all six workflows; `shellcheck -S error run healthcheck` exits 0. Tests 244/243 passed, 0 failed. Rebuild is `CACHED` on every layer, so the image is byte-identical.

**Risks.** It finds nothing today -- an alarm for a window, not a backlog. It is the first check here whose verdict is not reproducible from the tree, which is exactly why it stays off the pull request path; promoting it means answering that. It reports on `:latest`, which can lag master. First `schedule:` in the tree, et GitHub disables those silently after 60 days of inactivity. `linux/amd64` only, which measurement says loses nothing but is an assumption about Debian, written into the workflow.

Also filed while doing this: #293 (no `SECURITY.md`) and #294 (README's root table omits `saslauthd`).

Generated with [Claude Code](https://claude.com/claude-code)