### PR TITLE
Say what a secret file may end with, both halves of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ Every `POSTFIX_`, `POSTFIXMASTER_`, `POSTMAP_`, `OPENDKIM_` and `POSTSRSD_`
 variable can be suffixed with `_FILE` and given a path instead of a value. The
 container then reads the value from that file, so credentials never have to be
 put in the environment where `docker inspect`, the compose file and every
-process in the container can see them. A trailing newline is ignored.
+process in the container can see them. Trailing newlines are ignored, however
+many of them there are; trailing spaces are kept, so a file ending in one
+gives a value ending in one — worth checking on a password, where the
+difference is invisible.
 
 ```
 environment:


### PR DESCRIPTION
Closes #299

README's *Secrets from files* ended on "A trailing newline is ignored." The singular is narrower than the code, and it leaves out the half that costs something.

`secretsFromFiles` reads the value with `printf -v "$var" '%s' "$(< file)"`, and `$(< file)` strips **every** trailing newline, not one. Measured on bash 5.2:

```
$ printf 'value\n\n\n' > secret
$ printf -v v '%s' "$(< secret)" ; printf '[%s] length=%s\n' "$v" "${#v}"
[value] length=5
```

So an editor leaving a blank line at the end, a `docker secret` built from a heredoc, a file round-tripped through something that normalises the ending -- all of them already work, and the sentence read as though only the one-newline case were safe. A user checking whether their secret file is acceptable was getting a narrower answer than the truth.

The other half is the one worth warning about, et it was not there at all: trailing spaces are kept.

```
$ printf 'value  ' > secret
$ printf -v v '%s' "$(< secret)" ; printf '[%s] length=%s\n' "$v" "${#v}"
[value  ] length=7
```

A password with a space silently on the end is a credential that fails to authenticate with nothing in the log to say why, and the difference is invisible in every editor. Hence "worth checking on a password" rather than a promise about what postfix then does with the space: what is measured here is the value the entrypoint reads out of the file, not how a `sasl_passwd` table is parsed afterwards, and the README should not claim the second.

`CLAUDE.md` invariant 17 already has the plural -- *"`$(< file)` drops trailing newlines"* -- and is accurate as written, so it is left alone.

No test: nothing in the suite reads `README.md` (grepped for it, and for any open/read of a `.md` path -- there is none), and the behaviour itself is already exercised by every `_FILE` test, whose fixtures all write `"...\n"`. The two measurements above are la verification.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU