### PR TITLE
Write down that an agent here cannot open its own issue or pull request

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,25 @@ Notes a contributor will hit:
   correct behaviour, marked `xfail(strict=True)` with its issue. There are no
   current instances, and `xfail_strict` is not set in `pytest.ini`, so
   `strict=True` has to be written on each marker.
+- **Opening the issue or the pull request.** The integration a Claude session
+  here authenticates through can read this repository but cannot write to it:
+  creating an issue, creating a pull request and commenting on either all come
+  back `403 Resource not accessible by integration`, while `git push` to a
+  branch on a fork works. That is what issue #191 is about, and until it is
+  settled an agent cannot open the issue or the pull request its own change
+  needs. What it can do is push the branch and hand a person the link that
+  opens the form already filled in — `issues/new?title=…&body=…` for an issue,
+  `compare/master...<fork-owner>:<repo>:<branch>?expand=1` for a pull request.
+  Those links belong in the reply, written out in full: a file to download is
+  one step further from the browser, which is the one place they can be used.
+  Comments have no such link, so that case is the issue's own URL plus the text
+  to paste.
+- **Text bound for GitHub is not wrapped.** Issue bodies, pull request bodies
+  and comments go in as long lines and let GitHub reflow them to whatever width
+  the reader has; wrapped at 79 columns the way this file is, they render as a
+  narrow column down the left of a wide page. The wrapping this repository uses
+  is for what is *committed* — this file, the README, commit messages, the
+  comments inside `run` and the workflows — and stops at the edge of the tree.
 - **Docs.** User-visible behaviour goes in `README.md`. If a change makes the
   README wrong, the change is not finished. The same holds for this file, and
   it is the half that gets forgotten: it describes the tree, so a change to


### PR DESCRIPTION
Two conventions, both learned the hard way in one session, and neither of them about the code — so both sit in Conventions next to the docs rule rather than among the invariants.

**An agent here cannot open its own issue or pull request.** Creating an issue, creating a pull request and commenting on either all return `403 Resource not accessible by integration` on this repository, while reads and a `git push` to a fork branch work. Six attempts in one session hit it. Nothing in the tree said so, so each discovery cost the same detour: write the thing, try to file it, fail, and only then work out what to hand a person instead. #191 is where that access is tracked — if it is settled, this bullet is the thing to delete.

The other half is what to hand them, and it is not obvious either: github takes a pre-filled issue form on a query string (`issues/new?title=…&body=…`) and opens a pull request from a compare URL (`compare/master...<fork-owner>:<repo>:<branch>?expand=1`), so a session that cannot file can still get a person one click away from filed. Those links go in the reply written out in full, not in a file to download — a file is one step further from the browser, and the browser is the only place the link does anything. Comments have no query-string form at all, which is worth writing down so nobody looks for it twice.

**Text bound for GitHub is not wrapped.** Issue and pull request bodies were being wrapped at 79 columns — the width this file and the commit messages use — and rendering as a narrow column down the left of a wide page. GitHub reflows, so the wrapping this repository uses is for what is *committed*, and stops at the edge of the tree.

This pull request is the first thing written under both rules.

## Verification

Only `CLAUDE.md` changes, so no gate is affected; run anyway to confirm rather than assume — `ruff check --no-cache --select F tests` exits 0, `shellcheck -S error run healthcheck` exits 0, and `tests/test_ruleset.py` passes both of its tests. The added block itself wraps at 79 columns like the rest of the file, which is the distinction the second bullet is drawing.

No issue was filed for this one: `CLAUDE.md`-only changes have landed directly before (#244, #251, #258, #261, #262). Happy to file one if you would rather have the trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoXNxkLNasHDPWfHy46r8g
