### PR TITLE
Release the image master verified, instead of building another one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,10 @@ jobs:
           # action wants to see then.
           no-cache: ${{ inputs.no-cache || false }}
       -
+        # Tag refs are excluded here and handled by the step below, which
+        # builds nothing at all. What is left is branches and pull requests.
         name: Build and push branch or test PR
-        if: github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -130,6 +132,59 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: ${{ inputs.no-cache || false }}
+      -
+        # A release builds nothing, because the image it releases already
+        # exists. Every release tag this repository has cut names a commit
+        # that was on master first, so that commit was built here, pushed
+        # under "sha-<commit>", pulled back on both runner architectures and
+        # smoke-tested before latest was allowed onto it. Building again would
+        # publish something else under the version tags: the Dockerfile pins
+        # the Debian base by date, but the apt install below it is unversioned
+        # and reads the live archive, so a tag cut a fortnight after the merge
+        # resolves a package set the verified image never had -- and none of
+        # the jobs below look at a tag ref, so nothing would ever start it.
+        #
+        # So the version tags are pointed at that digest instead, with the
+        # same imagetools copy "Publish latest" makes: same manifest, same
+        # three architectures, same attestations. The source is docker_meta's
+        # own "sha-" tag rather than a sha spelled out here, so it cannot
+        # drift from what the master run pushed, and the inspect is what turns
+        # a tag on a commit master never published into a red job rather than
+        # a release built out of nothing.
+        name: Publish the release tags
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -eu
+          source=
+          targets=()
+          while IFS= read -r tag ; do
+            case "${tag}" in
+              "")      continue ;;
+              *:sha-*) source="${tag}" ;;
+              *)       targets+=(-t "${tag}") ;;
+            esac
+          done <<< "${TAGS}"
+
+          # A tag that is not semver produces no version tag at all, only the
+          # "sha-" one that master already pushed. There is nothing to move.
+          if [ ${#targets[@]} -eq 0 ] ; then
+            echo "::notice::${GITHUB_REF} carries no version tag, nothing to publish"
+            exit 0
+          fi
+          if [ -z "${source}" ] ; then
+            echo "::error::docker_meta produced no sha- tag for ${GITHUB_REF}"
+            exit 1
+          fi
+          if ! docker buildx imagetools inspect "${source}" > /dev/null 2>&1 ; then
+            echo "::error::${source} is not in the registry, so this commit was" \
+                 "never built and verified on master. Tag a commit that was."
+            exit 1
+          fi
+
+          docker buildx imagetools create "${targets[@]}" "${source}"
+          echo "released ${source}"
+        env:
+          TAGS: "${{ steps.docker_meta.outputs.tags }}"
 
   verify_published_amd64:
     name: "Verify Published Image (amd64)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ why merge commits name someone else's namespace.
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
 | `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `ruleset`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`, `upgrade`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
-| `.github/workflows/ci.yml` | `name: ci`. Four jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request, and the tags it pushes are docker_meta's for every ref — never `latest`. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls by digest the image that was just pushed and runs `pytest -m smoke` against it; the amd64 one first asserts the published manifest lists the three platforms the build asks for. `promote`, displayed as **Publish latest**: `master` only, `needs` all three, and points `latest` at that digest with `imagetools create`. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. The workflow also takes a `workflow_dispatch` with one boolean input, `no-cache`, wired into both build steps — the remediation lever for an **Image Scan** finding, and the three jobs above verify and tag what it republishes. |
+| `.github/workflows/ci.yml` | `name: ci`. Four jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request, and the tags it pushes are docker_meta's — never `latest`, and on a tag ref nothing at all: a release builds nothing and instead points the version tags at the `sha-<commit>` image `master` already published and verified. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls by digest the image that was just pushed and runs `pytest -m smoke` against it; the amd64 one first asserts the published manifest lists the three platforms the build asks for. `promote`, displayed as **Publish latest**: `master` only, `needs` all three, and points `latest` at that digest with `imagetools create`. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. The workflow also takes a `workflow_dispatch` with one boolean input, `no-cache`, wired into both build steps — the remediation lever for an **Image Scan** finding, and the three jobs above verify and tag what it republishes. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. Two jobs, each pinned and checksummed: `shellcheck`, displayed as **ShellCheck**, runs `shellcheck -S error run healthcheck` — the only threshold the two scripts pass; `ruff`, displayed as **Ruff**, runs `ruff check --no-cache --select F tests` — pyflakes over all the python in the tree. The only two linters there are, and neither reads a config file. |
@@ -298,11 +298,23 @@ that is the whole of the arrangement below: what the build pushes is reachable
 under `sha-<commit>` and its digest, `latest` is not written by the build at
 all, and **Publish latest** — a fourth job, `needs` on all three — moves the
 tag onto that digest afterwards. So a failure here is no longer a report on an
-image users are already pulling: the tag stays where it was. (issue #272) The amd64 one carries one step the
-other does not: each job pulls the entry of the manifest list matching its own
-runner, so a missing or mislabelled entry would leave both green while the
-architecture that lost it fails to pull at all — that step reads the list
-itself. (issue #284)
+image users are already pulling: the tag stays where it was. (issue #272) The
+amd64 one carries one step the other does not: each job pulls the entry of the
+manifest list matching its own runner, so a missing or mislabelled entry would
+leave both green while the architecture that lost it fails to pull at all —
+that step reads the list itself. (issue #284)
+
+A release tag reaches the same digest by a shorter road: it builds nothing.
+The commit a tag names has been on `master` first in every release this
+repository has cut, so its image is already in the registry under
+`sha-<commit>`, already pulled back and smoke-tested; **Build Image**'s last
+step copies that manifest onto the version tags with `imagetools`, the way
+**Publish latest** copies it onto `latest`. Rebuilding was the defect: the
+`Dockerfile` pins the Debian base by date but the `apt install` under it is
+unversioned, so a tag cut weeks after the merge resolved a package set no
+check had ever started, and none of the three jobs above look at a tag ref.
+The copy also refuses a tag on a commit `master` never published, which is
+the one thing nothing checked before.
 
 **Image Scan** does not run on a pull request either, and for a reason of its
 own rather than a scheduling one: `scan.yml` carries no `pull_request` trigger

--- a/README.md
+++ b/README.md
@@ -867,6 +867,13 @@ onto that image. It is the only check that looks at the image users actually
 pull, and it runs before they can pull it: an image that does not come up
 leaves `latest` where it was.
 
+A release is the same image again rather than another one. Pushing a version
+tag builds nothing: the commit it names was on `master` first, so its image is
+already in the registry, already pulled back and smoke-tested, and the version
+tags are pointed at it. So `1.2.18` and the `latest` it was cut from are the
+same bytes, and a tag on a commit `master` never published fails rather than
+releasing something no check has seen.
+
 | File | What it covers |
 | --- | --- |
 | `test_image.py` | The published image before anything runs: the defaults from the Dockerfile, the declared volumes, the exposed port, the health check, the programs the README has users run out of it |


### PR DESCRIPTION
Since #272, a push to `master` publishes under `sha-<commit>`, pulls that image back on both runner architectures, smoke-tests it, and only then moves `latest` onto its digest. A release tag got none of that -- and not for want of tests. The commit a tag names has been on `master` first in every release this repository has cut, so the suite had already run on it. What the tag published was **a different image**.

`ci.yml` fires on tags, the ref is not `master`, so "Build and push branch or test PR" ran a fresh buildx and pushed `1`, `1.2`, `1.2.18` and `sha-<commit>` out of it. The `Dockerfile` pins the Debian base by date, but the `apt install` under it is unversioned and resolves against the live archive whenever that layer is not a cache hit -- and the gha cache evicts after a week unused. A tag cut a fortnight after the merge therefore carried a package set nothing had ever started, and nothing would: `verify_published_amd64`, `verify_published_arm64` and `promote` are all `master` only. The version tags users pin were the one thing this repository published that no check had seen.

## What this does

A release builds nothing. The image is already in the registry under `sha-<commit>`, already pulled back and smoke-tested, so the version tags are copied onto it with the same `imagetools create` that `promote` uses -- same manifest, same three architectures, same attestations. `1.2.18` and the `latest` it was cut from are the same bytes rather than two builds of one tree, and a three-platform buildx run per release goes away with it.

The source is `docker_meta`'s own `sha-` tag rather than a sha spelled out in the step, so it cannot drift from what the `master` run pushed. Its `inspect` is also the check nobody was making: a tag on a commit `master` never published -- or whose `ci` run was cancelled in a merge burst -- fails the job instead of releasing something out of nothing. A tag that is not semver carries no version tag at all and is a no-op, as before.

## What it deliberately does not do

`test.yml` and `lint.yml` still do not run on tags. They would re-run, on the tag ref, the suite that already ran on that same commit on `master` -- which is what makes the promotion sound in the first place. Gating a release on a second opinion about the same commit is not what was missing.

## Verified

- the tag-selection shell run against `docker_meta`'s three real output shapes: a semver tag yields `-t <repo>:1 -t <repo>:1.2 -t <repo>:1.2.18` from `<repo>:sha-<commit>`; a non-semver tag exits 0 with nothing to publish; a tag list with no `sha-` entry exits 1;
- `actionlint` with shellcheck over `ci.yml` -- clean, and it is what reads the `run:` block this adds;
- `shellcheck -S error run healthcheck` -- clean;
- `tests/test_ruleset.py`'s two assertions pass. No job is added or renamed, so **the required-check ruleset needs no edit**;
- `v1.2.15`, `v1.2.16` and `v1.2.17` are each an ancestor of `master`, so every release so far would have found its `sha-` image where this looks for it.

## Note for whoever merges

The tag path cannot be exercised from a pull request -- it needs a real tag push. Everything the PR's own checks can show is unchanged behaviour on `master`, branches and pull requests; the release step is skipped on all of them. The first live exercise is the next release, and it fails closed: if anything is wrong the job goes red and the version tags simply are not written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDKhHayMMv2yusftfeYcEr
