### PR TITLE
Keep latest on master's head, not on whichever run finished last

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,9 +334,41 @@ jobs:
         # architectures and the same provenance attestations under it. Verified
         # with "--dry-run" against the published image, which returned the index
         # entry for entry.
+        #
+        # The stand-down above that command keeps latest following master rather
+        # than following whichever run finished last. Master runs overlap on
+        # purpose -- the concurrency block at the top of this file does not
+        # cancel them, because a cancelled master run is one that never
+        # published -- so an older run can arrive here after a newer one has
+        # already moved the tag, and moving it back would leave users pulling
+        # the older image until the next push, which on this repository can be
+        # days. The remote is asked rather than the checkout, because the
+        # question is what master points at now and not what it pointed at when
+        # this run started; "git ls-remote" needs no working tree, which is why
+        # this job can keep having no checkout step, and GIT_TERMINAL_PROMPT
+        # turns a repository git cannot reach into an immediate failure rather
+        # than a credential prompt nobody is there to answer. An unreadable
+        # answer stops the job instead of standing down, so that a tag which
+        # did not move is never mistaken for a tag that was not supposed to.
+        # (issue #306)
         run: |
+          head=$(git ls-remote "${SERVER}/${REPOSITORY}" refs/heads/master | cut -f1)
+          if [ -z "${head}" ] ; then
+            echo "could not read what master points at" >&2
+            exit 1
+          fi
+          if [ "${head}" != "${SHA}" ] ; then
+            echo "superseded: master is at ${head}, this run built ${SHA}."
+            echo "Leaving latest where the newer run put it."
+            exit 0
+          fi
+
           docker buildx imagetools create -t "${REPO}:latest" "${REPO}@${DIGEST}"
           echo "latest -> ${DIGEST}"
         env:
           REPO: "${{ steps.reponame.outputs.DOCKER_REPO }}"
           DIGEST: "${{ needs.docker.outputs.digest }}"
+          SERVER: "${{ github.server_url }}"
+          REPOSITORY: "${{ github.repository }}"
+          SHA: "${{ github.sha }}"
+          GIT_TERMINAL_PROMPT: "0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ why merge commits name someone else's namespace.
 | `tests/fixtures/smtp.py` | `smtplib` client against the shared `postfix` relay's mapped port 25. Function-scoped on purpose: the tests about rejected mail leave the connection broken. |
 | `tests/test_*.py` | `capabilities`, `client_tls`, `config`, `defaults`, `dkim`, `healthcheck`, `image`, `lifecycle`, `logging`, `postmaster`, `qshape`, `ruleset`, `sasl`, `secrets`, `sendmail`, `smtp`, `srs`, `upgrade`. Each has a row in the README's per-file table. |
 | `tests/img/postfix-logo.png` | The inline image `tests/test_sendmail.py` attaches, and compares byte for byte on the way out. |
-| `.github/workflows/ci.yml` | `name: ci`. Four jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request, and the tags it pushes are docker_meta's for every ref — never `latest`. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls by digest the image that was just pushed and runs `pytest -m smoke` against it; the amd64 one first asserts the published manifest lists the three platforms the build asks for. `promote`, displayed as **Publish latest**: `master` only, `needs` all three, and points `latest` at that digest with `imagetools create`. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. The workflow also takes a `workflow_dispatch` with one boolean input, `no-cache`, wired into both build steps — the remediation lever for an **Image Scan** finding, and the three jobs above verify and tag what it republishes. |
+| `.github/workflows/ci.yml` | `name: ci`. Four jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request, and the tags it pushes are docker_meta's for every ref — never `latest`. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls by digest the image that was just pushed and runs `pytest -m smoke` against it; the amd64 one first asserts the published manifest lists the three platforms the build asks for. `promote`, displayed as **Publish latest**: `master` only, `needs` all three, and points `latest` at that digest with `imagetools create` — unless `master` has moved on under it, in which case it stands down rather than tagging. Spelled out rather than a matrix, for the reason test.yml gives — a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. The workflow also takes a `workflow_dispatch` with one boolean input, `no-cache`, wired into both build steps — the remediation lever for an **Image Scan** finding, and the three jobs above verify and tag what it republishes. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
 | `.github/workflows/lint.yml` | `name: lint`. Two jobs, each pinned and checksummed: `shellcheck`, displayed as **ShellCheck**, runs `shellcheck -S error run healthcheck` — the only threshold the two scripts pass; `ruff`, displayed as **Ruff**, runs `ruff check --no-cache --select F tests` — pyflakes over all the python in the tree. The only two linters there are, and neither reads a config file. |
@@ -298,7 +298,14 @@ that is the whole of the arrangement below: what the build pushes is reachable
 under `sha-<commit>` and its digest, `latest` is not written by the build at
 all, and **Publish latest** — a fourth job, `needs` on all three — moves the
 tag onto that digest afterwards. So a failure here is no longer a report on an
-image users are already pulling: the tag stays where it was. (issue #272) The amd64 one carries one step the
+image users are already pulling: the tag stays where it was. (issue #272) That
+job asks the remote what `master` points at before it tags, and stands down
+when the answer is not the commit it built: master runs are deliberately not
+cancelled, so two merges close together overlap, and the property wanted is
+that `latest` follows `master`'s head rather than whichever run happened to
+finish last. Standing down is a green job, an unreadable answer is a red one —
+a tag that did not move must not be mistaken for a tag that was not supposed
+to. (issue #306) The amd64 one carries one step the
 other does not: each job pulls the entry of the manifest list matching its own
 runner, so a missing or mislabelled entry would leave both green while the
 architecture that lost it fails to pull at all — that step reads the list
@@ -367,7 +374,10 @@ Notes a contributor will hit:
 - `ci.yml` runs on pushes to every branch and tag, plus `pull_request` and
   `workflow_dispatch`; `test.yml` runs on pushes to `master` only, plus
   `pull_request` and `workflow_dispatch`. Both cancel in-flight runs on any ref
-  but `master`. `scan.yml` is the only one with a `schedule:`, and the only one
+  but `master`. That exemption is deliberate — a cancelled `master` run is one
+  that never published — and it is what makes two merges close together
+  overlap, which is why **Publish latest** checks `master`'s head before it
+  moves the tag. `scan.yml` is the only one with a `schedule:`, and the only one
   with no `pull_request` trigger.
 - Version skew: CI pins Python 3.13, and nothing pins a Python version locally.
   The Python dependencies are pinned exactly (`tests/requirements.txt`); their


### PR DESCRIPTION
Closes #306

The `concurrency` block at the top of `ci.yml` exempts master from cancellation, and says why: *"A new push makes the images an in-flight run would produce obsolete, except on master where the run publishes latest."* So two merges close together give two overlapping runs, and until now nothing ordered what they did at the end of them.

Since #272 the end of a master run is the `promote` job, which moves `latest` onto the digest its own `docker` job built. Nothing checked that the commit behind that digest was still master's head. An older run reaching `promote` after a newer one therefore moved `latest` back onto the older image, where it stayed until the next push to master -- hours or days on this repository, whose pushes come in bursts and then stop.

Not hypothetical: five pull requests merged inside about half an hour this evening, and the window is now wider than it used to be. Before #272 it was the build alone; it is now the build plus both **Verify Published Image** jobs, whose duration is a registry pull and two container starts -- the part that varies most.

So the promote step asks the remote what master points at, and stands down when the answer is not the commit it built. A newer run promotes its own image and the older one leaves it alone, which is the property wanted -- `latest` follows master's head -- rather than "whoever finishes last wins".

Four decisions inside that are worth recording:

- The check is in the **same step** as the tagging rather than a step above it with an `if:` on the promotion. One step is the smallest window between asking and acting, and it needs no output plumbing.
- The **remote** is asked, not the checkout: the question is what master points at now, not what it pointed at when this run started. `git ls-remote` needs no working tree, so `promote` keeps having no checkout step.
- Standing down **exits 0**. A superseded run did its job correctly and a red X on master for it would be noise.
- An unreadable answer **exits 1**. A tag that did not move must not be mistaken for a tag that was not supposed to, and `GIT_TERMINAL_PROMPT=0` keeps a repository git cannot reach from becoming a credential prompt that hangs until the job timeout rather than failing.

A job-level `concurrency` group with `cancel-in-progress` was considered and left out. It does not close the race on its own -- an older promotion that starts after the newer one has finished finds the group free and proceeds -- and with this guard the job it would have cancelled costs one `ls-remote`.

Verified as far as it can be from here: the workflow parses, `tests/test_ruleset.py` still passes, and the three branches of the guard were run as written against this repository with the real `ls-remote`. Given master's actual head it reaches the imagetools command; given a stale sha it prints the "superseded" line naming both commits and exits 0; against a repository git cannot read it prints "could not read what master points at" and exits 1. The publish path itself only ever runs on master, so this cannot be exercised before it is merged -- the same limit #272 landed under.

`CLAUDE.md` is updated in the three places that described the old behaviour: le `ci.yml` layout row, the paragraph explaining the digest/tag arrangement, and the bullet about which workflows cancel in-flight runs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU