### PR TITLE
Tell gh which repository to act on

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -158,6 +158,13 @@ jobs:
         if: steps.scan.outputs.count != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job checks nothing out, on purpose -- trivy pulls the
+          # published manifest itself. gh resolves the repository it acts on
+          # from --repo, then GH_REPO, then the git remotes of the working
+          # directory; with no checkout there are none, so without this it
+          # exits "failed to run git: fatal: not a git repository" before it
+          # ever reaches the API.
+          GH_REPO: ${{ github.repository }}
           IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
@@ -195,6 +202,13 @@ jobs:
         if: steps.scan.outputs.count == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job checks nothing out, on purpose -- trivy pulls the
+          # published manifest itself. gh resolves the repository it acts on
+          # from --repo, then GH_REPO, then the git remotes of the working
+          # directory; with no checkout there are none, so without this it
+          # exits "failed to run git: fatal: not a git repository" before it
+          # ever reaches the API.
+          GH_REPO: ${{ github.repository }}
           IMAGE: "${{ steps.reponame.outputs.DOCKER_REPO }}:latest"
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,7 +832,10 @@ changing any of them.
     2026-03-19, when 76 of its 77 version tags were force-pushed to a
     credential stealer — a tag pin would not have helped, and the job needs no
     checkout, no buildx and no QEMU, so it costs one `curl` to skip the
-    dependency entirely. Nothing bumps that pin, and unusually little is lost
+    dependency entirely -- and having no checkout is why the two `gh` steps set
+    `GH_REPO`: `gh` resolves the repository it acts on from `--repo`, then that
+    variable, then the working directory's git remotes, and with nothing
+    checked out there are none. Nothing bumps that pin, and unusually little is lost
     by that: the database is fetched fresh on every run and is what carries the
     signal.
     The **Verify Published Image** jobs in `ci.yml` look at the same artefact


### PR DESCRIPTION
Closes #315.

`scan.yml` checks nothing out -- trivy pulls the published manifest itself -- and its two `gh` steps set only `GH_TOKEN`. `gh` resolves the repository from `--repo`, then `GH_REPO`, then the working directory's git remotes; with no checkout there are none, so both steps exit with `failed to run git: fatal: not a git repository` before reaching the API.

Reproduced with gh 2.64.0 outside a git repository: without `GH_REPO` that is the whole output, with it set gh reaches the API.

**This breaks the green path, not an edge case.** *Close the finding issue* runs whenever the scan is clean -- the expected daily state -- so the first scheduled run would have gone red for a reason unrelated to vulnerabilities, and every morning after. *Open the finding issue* would have failed the same way on the day a finding appeared, so the alarm would not have fired either.

Nothing static catches this: actionlint and shellcheck are clean on the file either way, which is why it survived review. The workflow had never executed when this was found -- merged in #307, and the daily cron had not come round -- so all of it had been verified locally rather than in Actions.

`CLAUDE.md` invariant 34 gains the clause, since "no checkout" is what makes `GH_REPO` necessary.

**Verified:** actionlint with shellcheck 0.11.0 clean over all seven workflows, `shellcheck -S error run healthcheck` exits 0, `ruff check --no-cache --select F tests` passes, `tests/test_ruleset.py` 2 passed.

**Still worth doing after this merges:** run `scan` once from the Actions tab (`workflow_dispatch`), so the workflow is finally exercised end to end rather than waiting on the cron.

Generated with [Claude Code](https://claude.com/claude-code)