### PR TITLE
Record why the two POSTFIX loops are two, and assert it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -895,3 +895,20 @@ changing any of them.
     until the `FROM` line moves. Without the input, the only answer to a
     finding is to wait two to three weeks for the next `trixie-<date>-slim`
     tag. (issue #269)
+
+35. **The trailing underscore in `${!POSTFIX_*}` is what keeps the two
+    `postconf` loops apart.** Bash's `${!prefix*}` is a literal prefix test on
+    variable names, so `POSTFIX_` demands `_` at offset 7 where
+    `POSTFIXMASTER_` has `M`; that character, and nothing else, is why the
+    `POSTFIX_` loop does not also swallow every `POSTFIXMASTER_` variable.
+    Dropping it feeds them to `postconf -e` as well, and the offsets are
+    coupled to the spelling too — `${e:8}` then cuts one character further in,
+    so `POSTFIXMASTER_submission__inet` lands in `main.cf` as
+    `ASTER_submission__inet`. Nothing loud happens: the service is still added
+    correctly by the second loop, the container comes up healthy and relays,
+    and the only trace is one `postconf: warning: unused parameter`. What
+    makes it more than untidy is invariant 17 — a `POSTFIXMASTER_<name>_FILE`
+    secret is resolved *before* these loops, so the same edit writes a
+    resolved credential into `main.cf`.
+    `tests/test_config.py` asserts a `POSTFIXMASTER_` variable leaves no trace
+    there, which fails under that edit and passes today. (issue #314)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,8 +9,8 @@ import smtplib
 
 import pytest
 
-from tests.helpers import (container_exec, esmtp_features, listening_ports, postconf,
-                           send, smtp_connect, wait_for_log)
+from tests.helpers import (container_exec, container_log, esmtp_features,
+                           listening_ports, postconf, send, smtp_connect, wait_for_log)
 
 
 def test_postfix_variables_configure_main_cf(postfix_factory, mailpit):
@@ -65,6 +65,36 @@ def test_postfixmaster_variables_configure_master_cf(postfix_factory, mailpit):
     send(relay, port=587, subject='through submission')
 
     assert mailpit.wait_for_message('through submission')
+
+
+def test_postfixmaster_variables_leave_nothing_in_main_cf(postfix_factory):
+    """The two loops in "run" are two only because "${!POSTFIX_*}" keeps its
+    trailing underscore.
+
+    Bash matches variable names by literal prefix, so POSTFIX_ demands "_"
+    where POSTFIXMASTER_ has "M". Drop that one character -- the sort of edit
+    a tidy-up makes -- and every POSTFIXMASTER_ variable goes to "postconf -e"
+    as well, landing the master.cf entry's value in main.cf under a mangled
+    name while the service is still added correctly and the relay still comes
+    up healthy. Measured on the built image with "run" mounted that way:
+    "ASTER_submission__inet = submission inet n - y - - smtpd" in main.cf, one
+    postconf warning, and every other assertion in this file still passing.
+
+    What makes it worth an assertion rather than a comment is where the value
+    lands: a POSTFIXMASTER_<name>_FILE secret is resolved before these loops
+    (invariant 17), so the same edit would write a resolved credential into
+    main.cf. (issue #314)
+    """
+    relay = postfix_factory(
+        env={'POSTFIXMASTER_submission__inet': 'submission inet n - y - - smtpd'},
+        ports=(25, 587),
+    )
+
+    main_cf = container_exec(relay, ["cat", "/etc/postfix/main.cf"])
+
+    assert 'submission__inet' not in main_cf, (
+        "a POSTFIXMASTER_ variable reached main.cf: the POSTFIX_ loop matched it too")
+    assert 'unused parameter' not in container_log(relay)
 
 
 def test_postmap_variables_create_indexed_tables(postfix_factory, mailpit):


### PR DESCRIPTION
Closes #314.

## The character that cannot go

`run` turns its environment into configuration through two loops that read as one loop written twice:

```bash
for e in ${!POSTFIX_*} ; do postconf -e "${e:8}=${!e}" ; done
for e in ${!POSTFIXMASTER_*} ; do v="${e:14}" && postconf -Me "${v//__/\/}=${!e}"; done
```

The only thing keeping the first from swallowing the second is the **trailing underscore**. Bash's `${!prefix*}` is a literal prefix test on variable names, so `POSTFIX_` demands `_` at offset 7 where `POSTFIXMASTER_` has `M`. The offsets are coupled to the spelling too, so `${e:8}` then cuts one character further in.

## What that edit actually does — measured, not reasoned

`run` mounted with `${!POSTFIX_*}` changed to `${!POSTFIX*}`, one `POSTFIXMASTER_submission__inet` set:

```
$ docker exec c grep -n ASTER /etc/postfix/main.cf
76:ASTER_submission__inet = submission inet n - y - - smtpd

$ docker exec c postconf -M submission/inet
submission inet  n       -       y       -       -       smtpd

# on stderr, once:
postconf: warning: /etc/postfix/main.cf: unused parameter: ASTER_submission__inet=...
```

The service is still added correctly by the second loop, the relay comes up healthy and relays, and one warning is the whole trace. Nothing in the suite noticed: the existing test asserts the service exists, which it does.

## Why it is more than untidy

Invariant 17: a `POSTFIXMASTER_<name>_FILE` secret is resolved **before** these loops. So the same edit writes a resolved credential into `main.cf` — the file the `_FILE` mechanism exists to keep it out of.

## What this adds

- **Invariant 35** in `CLAUDE.md`. Its neighbours are already documented (2 on the `postconf -e` guards, 15 on the opendkim loop, 17 on `secretsFromFiles`, 24 on `${v//__/\/}`); this one was not.
- **An assertion** in `tests/test_config.py`: a `POSTFIXMASTER_` variable leaves nothing in `main.cf` and draws no unused-parameter warning.

The test was run **against a container carrying the edit**, not only against a correct one: both of its assertions fail there and pass here. That is la différence entre un test et un commentaire.

## Verified

`pytest` -> **246 passed, 2 skipped**, against 245 before. `ruff check --no-cache --select F tests` clean. `run` is not touched — it is correct at all three sites today.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
