### PR TITLE
Fail the head check fast when the remote cannot be reached

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,15 @@ jobs:
           if [ "${head}" != "${{ github.sha }}" ] ; then
             echo "::notice::${{ github.sha }} is no longer master's head (${head}); leaving latest to that run"
           fi
+        env:
+          # The other half of the emptiness check above, for the case where the
+          # command returns nothing at all rather than an empty string: git
+          # answers a repository it cannot reach by asking for credentials, and
+          # nobody is here to type them. Without this the job sits on that
+          # prompt until the job timeout above expires, long after the answer
+          # was known to be unavailable; with it, git fails at once and the
+          # check exits 1 as it means to.
+          GIT_TERMINAL_PROMPT: "0"
       -
         name: Login to DockerHub
         # After the check above, and gated with it: standing down writes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,11 +301,17 @@ that is the whole of the arrangement below: what the build pushes is reachable
 under `sha-<commit>` and its digest, `latest` is not written by the build at
 all, and **Publish latest** — a fourth job, `needs` on all three — moves the
 tag onto that digest afterwards. So a failure here is no longer a report on an
-image users are already pulling: the tag stays where it was. (issue #272) The
-amd64 one carries one step the other does not: each job pulls the entry of the
-manifest list matching its own runner, so a missing or mislabelled entry would
-leave both green while the architecture that lost it fails to pull at all —
-that step reads the list itself. (issue #284)
+image users are already pulling: the tag stays where it was. (issue #272) That
+job asks the remote what `master` points at before it tags, and stands down
+when the answer is not the commit it built: master runs are deliberately not
+cancelled, so two merges close together overlap, and the property wanted is
+that `latest` follows `master`'s head rather than whichever run happened to
+finish last. Standing down is a green job, an unreadable answer is a red one —
+a tag that did not move must not be mistaken for a tag that was not supposed
+to. (issue #306) The amd64 one carries one step the other does not: each job
+pulls the entry of the manifest list matching its own runner, so a missing or
+mislabelled entry would leave both green while the architecture that lost it
+fails to pull at all — that step reads the list itself. (issue #284)
 
 A release tag reaches the same digest by a shorter road: it builds nothing.
 The commit a tag names has been on `master` first in every release this
@@ -382,8 +388,11 @@ Notes a contributor will hit:
 - `ci.yml` runs on pushes to every branch and tag, plus `pull_request` and
   `workflow_dispatch`; `test.yml` runs on pushes to `master` only, plus
   `pull_request` and `workflow_dispatch`. Both cancel in-flight runs on any ref
-  but `master`. `scan.yml` is the only one with a `schedule:`, and the only one
-  with no `pull_request` trigger.
+  but `master`. That exemption is deliberate — a cancelled `master` run is one
+  that never published — and it is what makes two merges close together
+  overlap, which is why **Publish latest** checks `master`'s head before it
+  moves the tag. `scan.yml` is the only one with a `schedule:`, and the only
+  one with no `pull_request` trigger.
 - Version skew: CI pins Python 3.13, and nothing pins a Python version locally.
   The Python dependencies are pinned exactly (`tests/requirements.txt`); their
   transitive dependencies are not, and there is no lock file, so a run can


### PR DESCRIPTION
Follow-up to #310, carrying the two things worth keeping from the duplicate #313 that was closed in its favour.

## The prompt that never gets answered

#310 guards the promotion with a question to the remote, and guards the answer with an emptiness check whose reasoning is exactly right: the status of `ls-remote | cut` is cut's, so a failure to reach github arrives as an empty string rather than a non-zero exit, and reading that as "superseded" would quietly stop promoting anything ever again.

That covers the command returning nothing. What it does not cover is the command returning nothing *yet*: git answers a repository it cannot reach by asking for credentials, and no one is watching the runner to type them. The step then sits on that prompt until the job timeout expires, long after the answer was known to be unavailable, and the run goes red for having taken too long rather than for the reason it actually failed.

`GIT_TERMINAL_PROMPT: "0"` turns that into an immediate failure, so #310's emptiness check gets to do its job and say what went wrong. The guard's behaviour is unchanged -- this only decides how fast git gives up before it runs.

## What #310 started in CLAUDE.md

It updated the `ci.yml` layout row. Two other passages still described the promotion as it was:

- the paragraph explaining the digest/tag arrangement, which ended on "the tag stays where it was" and said nothing about which run's tag wins;
- the bullet recording that both workflows "cancel in-flight runs on any ref but `master`" -- the exemption that creates the race, now pointing at what answers it.

Leaving those two is the staleness #295 and #301 were filed about, one window later. The paragraph is also re-wrapped: the insertion left two lines stepped against the rest of the file.

## Verified

The workflow parses and `tests/test_ruleset.py` passes. No script, test or image content is touched, so nothing else in the suite can be affected by it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU