### PR TITLE
Take the server from the context, and say what the prompt flag does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,23 +395,29 @@ jobs:
         # anything ever again -- the one outcome worse than promoting the wrong
         # image. (issue #306)
         run: |
-          head=$(git ls-remote "https://github.com/${{ github.repository }}" refs/heads/master | cut -f1)
+          head=$(git ls-remote "${SERVER}/${REPOSITORY}" refs/heads/master | cut -f1)
           if [ -z "${head}" ] ; then
             echo "::error::could not read what master points at"
             exit 1
           fi
           echo "head=${head}" >> "${GITHUB_OUTPUT}"
-          if [ "${head}" != "${{ github.sha }}" ] ; then
-            echo "::notice::${{ github.sha }} is no longer master's head (${head}); leaving latest to that run"
+          if [ "${head}" != "${SHA}" ] ; then
+            echo "::notice::${SHA} is no longer master's head (${head}); leaving latest to that run"
           fi
         env:
-          # The other half of the emptiness check above, for the case where the
-          # command returns nothing at all rather than an empty string: git
-          # answers a repository it cannot reach by asking for credentials, and
-          # nobody is here to type them. Without this the job sits on that
-          # prompt until the job timeout above expires, long after the answer
-          # was known to be unavailable; with it, git fails at once and the
-          # check exits 1 as it means to.
+          # Where this is running is in the context; writing the host out is one
+          # more line that has to be edited if it ever stops being github.com.
+          SERVER: "${{ github.server_url }}"
+          REPOSITORY: "${{ github.repository }}"
+          SHA: "${{ github.sha }}"
+          # Belt and braces on the emptiness check above: git answers a
+          # repository it cannot reach by asking for credentials, and this says
+          # there is nobody to ask. It pins what already happens rather than
+          # creating it -- measured with no terminal attached, which is what a
+          # runner is, git gives up in about a second on its own: "could not
+          # read Username ... No such device or address", exit 128. What it
+          # buys is holding that if a terminal or an askpass helper is ever
+          # there to answer.
           GIT_TERMINAL_PROMPT: "0"
       -
         name: Login to DockerHub


### PR DESCRIPTION
Follow-up to #310 and #319, on the same step: two things, one concern -- the head check should not write out where it is running, and its comment should describe what happens.

## `github.server_url`

Replaces the hard-coded `https://github.com`. The context knows the host; spelling it out is one more line that has to be edited if it ever stops being true. The values move into `env:` alongside the flag #319 added, which is also why the script now reads `${SERVER}` and `${SHA}` rather than expressions inline -- the shape the promotion step below it already had.

## The comment on `GIT_TERMINAL_PROMPT` was wrong

#319 landed it saying the job *"sits on that prompt until the job timeout above expires"*. It does not. Measured with no terminal attached, which is what a runner is:

```
$ git ls-remote https://github.com/wader/does-not-exist-xyz refs/heads/master
fatal: could not read Username for 'https://github.com': No such device or address
exit=128 after 1s
```

git gives up on its own in about a second. So the flag **pins** that rather than creating it, and what it buys is holding it if a terminal or an askpass helper is ever there to answer.

The flag is worth keeping either way -- only the reason was wrong. A comment stating a mechanism that is not the mechanism is the kind of thing this file is careful about, and it would have been read as fact par quiconque touche l'étape ensuite.

## Verified

The step's script run as the job will run it, in its new form:

| Case | Result |
| --- | --- |
| `SHA` = master's head | exit 0, writes the output the promotion is gated on |
| `SHA` = another commit | the notice, output left at the newer head |
| a repository that cannot be read | the error, exit 1 |

Workflows parse, `tests/test_ruleset.py` passes, `ruff check --no-cache --select F tests` clean. Nothing outside `ci.yml` changes, so the suite cannot be affected.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
