### PR TITLE
Gate the third shell script, which already passed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,8 @@ concurrency:
 
 # What the ShellCheck gate is, and what it deliberately is not.
 #
-# It runs shellcheck at "-S error", which is the threshold the two scripts pass
-# today and the only one that does: "-S warning" fails on the SC2034 in
+# It runs shellcheck at "-S error", which is the threshold the image scripts
+# pass today and the only one that does: "-S warning" fails on the SC2034 in
 # awaitGreeting, and the default threshold fails on that plus eight notes,
 # two of which are deliberate and must not be "fixed" -- that SC2034 is a retry
 # counter the loop body has no reason to read, and the SC2086 in healthcheck is
@@ -58,13 +58,18 @@ jobs:
             --strip-components=1 -C "${RUNNER_TEMP}/shellcheck"
           echo "${RUNNER_TEMP}/shellcheck" >> "${GITHUB_PATH}"
 
-      - name: Check run and healthcheck
-        # The only two shell scripts in the tree. Both carry a #!/bin/bash
-        # shebang, which is where shellcheck reads the dialect from, so there
-        # is no -s to pass.
+      - name: Check the shell scripts
+        # Every shell script in the tree. run and healthcheck are what goes
+        # into the image; the hook is what stands a Claude Code on the web
+        # session up, so when it breaks it breaks these gates rather than the
+        # image -- and it breaks them quietly, since it deliberately exits 0
+        # whatever happens and reports only on stderr. It passes at the stock
+        # threshold as well as this one, so gating it can only ever go red on
+        # a future edit to it. All three carry a #!/bin/bash shebang, which is
+        # where shellcheck reads the dialect from, so there is no -s to pass.
         run: |
           shellcheck --version
-          shellcheck -S error run healthcheck
+          shellcheck -S error run healthcheck .claude/hooks/session-start.sh
 
   # What the Ruff gate is, and what it deliberately is not.
   #
@@ -116,7 +121,7 @@ jobs:
 
       - name: Check tests
         # tests/ is where all the python is, and naming it keeps this gate as
-        # narrow as the one above, which names its two scripts rather than
+        # narrow as the one above, which names its scripts rather than
         # scanning the tree.
         run: |
           ruff --version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ why merge commits name someone else's namespace.
 | `.github/workflows/ci.yml` | `name: ci`. Four jobs. `docker`, displayed as **Build Image**: buildx over `linux/amd64,linux/arm/v7,linux/arm64/v8`, GHA build cache, nothing pushed on a pull request, and the tags it pushes are docker_meta's — never `latest`, and on a tag ref nothing at all: a release builds nothing and instead points the version tags at the `sha-<commit>` image `master` already published and verified. `verify_published_amd64` and `verify_published_arm64`, displayed as **Verify Published Image (amd64)** and **(arm64)**: `needs: docker`, `master` only, each pulls by digest the image that was just pushed and runs `pytest -m smoke` against it; the amd64 one first asserts the published manifest lists the three platforms the build asks for. `promote`, displayed as **Publish latest**: `master` only, `needs` all three, and points `latest` at that digest with `imagetools create` — after checking the commit is still `master`'s head, since master runs are not cancelled and two of them would otherwise race to write the tag. Spelled out rather than a matrix, for the reason test.yml gives — the job name is what a required status check and the auto-merge workflow match on — and for one of its own: a matrix expands `${{ matrix.arch }}` only in the runs it starts, so a pull request, where the `if` skips the job whole, reported the raw expression as the check's name. The workflow also takes a `workflow_dispatch` with one boolean input, `no-cache`, wired into both build steps — the remediation lever for an **Image Scan** finding, and the three jobs above verify and tag what it republishes. |
 | `.github/workflows/test.yml` | `name: test`. Four jobs: **Event File**, **Pytest**, **Pytest (arm64)** and **Pytest (arm/v7, emulated)**. Spelled out rather than written as a matrix; the file says why. |
 | `.github/workflows/test-results.yml` | On `workflow_run` of `test`, downloads the junit artifacts and publishes them as the **Test Results** check. |
-| `.github/workflows/lint.yml` | `name: lint`. Two jobs, each pinned and checksummed: `shellcheck`, displayed as **ShellCheck**, runs `shellcheck -S error run healthcheck` — the only threshold the two scripts pass; `ruff`, displayed as **Ruff**, runs `ruff check --no-cache --select F tests` — pyflakes over all the python in the tree. The only two linters there are, and neither reads a config file. |
+| `.github/workflows/lint.yml` | `name: lint`. Two jobs, each pinned and checksummed: `shellcheck`, displayed as **ShellCheck**, runs `shellcheck -S error` over `run`, `healthcheck` and the session-start hook — the only threshold the image scripts pass; `ruff`, displayed as **Ruff**, runs `ruff check --no-cache --select F tests` — pyflakes over all the python in the tree. The only two linters there are, and neither reads a config file. |
 | `.github/workflows/scan.yml` | `name: scan`. One job, `trivy`, displayed as **Image Scan**: on a daily `schedule:` and on `workflow_dispatch`, downloads a pinned, checksummed trivy and scans the *published* image at `--ignore-unfixed --severity HIGH,CRITICAL`. The only workflow with no `pull_request` trigger, and the only one with a `schedule:`. Files one issue when it finds something and closes it when it stops, which is the only thing in the tree that writes to the tracker. |
 | `.github/workflows/dependabot-auto-merge.yml` | On `pull_request`, for `dependabot[bot]` only: enables auto-merge for semver-minor and semver-patch updates. Its header comment records the check names that *exist* and the two repository settings it depends on; which of them are *required* is the ruleset below. |
 | `SECURITY.md` | Where to report a vulnerability, and — the half that is actually load-bearing — what is *not* one here: the open relay default (invariant 23), no client TLS, starting as root, and a scanner row with no fixed version. Without that, a policy invites reports about behaviour the README documents as deliberate. Names no address: it points at github's private vulnerability reporting, which needs a repository setting rather than a file. |
@@ -196,7 +196,8 @@ until CI runs.
 ### Lint
 
 ```bash
-shellcheck -S error run healthcheck        # what CI runs; exits 0
+shellcheck -S error run healthcheck .claude/hooks/session-start.sh
+                                           # what CI runs; exits 0
 shellcheck run healthcheck                 # everything, at the stock threshold
 
 ruff check --no-cache --select F tests     # what CI runs; exits 0
@@ -206,10 +207,15 @@ ruff check --statistics --select ALL tests # everything ruff has, for reference
 `run` and `healthcheck` are the two scripts that go into the image, and
 `.github/workflows/lint.yml` gates them at `-S error` on every pull request —
 the **ShellCheck** check in the table below. That threshold is not a stepping
-stone to a stricter one: it is the only one the scripts pass, and the findings
+stone to a stricter one: it is the only one *they* pass, and the findings
 between it and the default are either noise or deliberate. The third shell
-script in the tree, the hook under `.claude/`, is not gated: it is no part of
-what ships.
+script in the tree, the hook under `.claude/`, is gated by the same command
+and is not what sets the threshold: it passes at the stock one too, with
+nothing to report, so including it can only go red on a future edit to it.
+That is the whole reason it is there — it is no part of what ships, but it is
+what stands a session up, so when it breaks it breaks these gates rather than
+the image, and it breaks them quietly: the hook exits 0 whatever happens and
+says so only on stderr. (issue #303)
 
 With shellcheck 0.11.0, which is the version `lint.yml` pins:
 
@@ -285,7 +291,7 @@ display `name:`, so on an ordinary pull request it appears as a skipped
 | **Pytest (arm64)** | `test.yml` | The same, natively, on `ubuntu-24.04-arm`. |
 | **Pytest (arm/v7, emulated)** | `test.yml` | Pins the QEMU binfmt image, builds `linux/arm/v7` and runs `pytest -m smoke -n0` against it — four tests, and the only ones that ever start the image whose packaging differs. It ran on `master` and behind a `test-emulated` label until #273; the label is gone, and 42-152s against 174-275s for either native job is why it can be on the path a pull request waits on without lengthening it. |
 | **Event File** | `test.yml` | Uploads the triggering event payload for the reporter. |
-| **ShellCheck** | `lint.yml` | Downloads shellcheck at the version and sha256 pinned in the job's `env:`, then `shellcheck -S error run healthcheck`. Seconds, no docker. See [Lint](#lint) for why that threshold and not a stricter one. |
+| **ShellCheck** | `lint.yml` | Downloads shellcheck at the version and sha256 pinned in the job's `env:`, then `shellcheck -S error` over `run`, `healthcheck` and `.claude/hooks/session-start.sh`. Seconds, no docker. See [Lint](#lint) for why that threshold and not a stricter one. |
 | **Ruff** | `lint.yml` | The same shape, one job over: downloads ruff at the version and sha256 pinned in the job's `env:`, then `ruff check --no-cache --select F tests`. Seconds, no docker. See [Lint](#lint) for why that selection and not a wider one, and why it is spelled out rather than inherited. |
 | **Test Results** | `test-results.yml` | Runs on `workflow_run` of `test`, downloads the junit artifacts and publishes them onto the PR. |
 


### PR DESCRIPTION
Closes #303

`lint.yml` ran `shellcheck -S error run healthcheck`, and the comment above it called those "the only two shell scripts in the tree". There are three: `.claude/hooks/session-start.sh` has been unread by anything since it was added.

`CLAUDE.md` gave the reason -- "it is no part of what ships" -- which is a fair reason not to worry about it and not a reason to leave it unchecked, because checking it costs nothing. Measured with shellcheck 0.11.0, the version the job pins, fetched and checksummed exactly as the job fetches it:

```
$ shellcheck -S error .claude/hooks/session-start.sh ; echo $?
0
$ shellcheck .claude/hooks/session-start.sh ; echo $?    # stock threshold
0
$ shellcheck -S error run healthcheck .claude/hooks/session-start.sh ; echo $?
0
```

So it passes at the gate's threshold and at the default, with nothing to report at either, and adding it can only ever go red on a future edit to that file.

Which is the point rather than tidiness. That hook is what stands a Claude Code on the web session up -- it starts the docker daemon and installs the test dependencies -- so when it breaks, what it breaks is these gates rather than the image. And it breaks them quietly: it is deliberately best-effort, exits 0 whatever happens, and reports only on stderr, which is exactly the failure a linter is good at catching before it happens.

Deliberately no separate threshold for it. One command and one threshold is worth more than the special case, and the reason `-S error` is the ceiling belongs to `run` and `healthcheck`, not to this file -- so the wording that explains the threshold now says the image scripts are what set it.

Statements that moved with the change:

- `lint.yml`'s step name and its comment, the latter having claimed there were two scripts;
- its header comment, which attributed the threshold to "the two scripts";
- the `ruff` job's comment, which pointed at "its two scripts" next door;
- `CLAUDE.md` in four places -- the `lint.yml` layout row, the copy-pasteable command marked "what CI runs", the paragraph that said the hook is not gated, and the **ShellCheck** row of the required-checks table.

`README.md` is deliberately untouched. It never mentions `.claude` or Claude at all, its sentence "Continuous integration runs shellcheck over both" stays true of the two scripts it is about, et its command block is not labelled as what CI runs -- unlike `CLAUDE.md`'s, which is, and which moved.

Verified on this branch: the command above exits 0 with the pinned shellcheck, `lint.yml` parses, and `tests/test_ruleset.py` passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU