### PR TITLE
Give file_missing the caller it was written for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ why merge commits name someone else's namespace.
 | `.claude/hooks/session-start.sh` | Starts the docker daemon and installs `tests/requirements.txt`, because a Claude Code on the web container has neither and both gates need them. Guarded on `CLAUDE_CODE_REMOTE=true`, so a local checkout is untouched, and best-effort: a failed step explains itself on stderr and the hook still exits 0, so check stderr before believing a build or test failure. |
 | `tests/__init__.py` | Empty; makes `tests` a package, which is what lets `conftest.py` name plugins as `tests.fixtures.*` and lets modules do `from tests.helpers import …`. pytest therefore has to be run from the repo root. There is no `tests/fixtures/__init__.py`. |
 | `tests/conftest.py` | Registers the four fixture modules as pytest plugins, and defines the failure plumbing: `print_log_on_failure`, an autouse `shared_container_logs` fixture, and a `pytest_runtest_makereport` wrapper hook that stashes the report on the item. |
-| `tests/helpers.py` | The shared vocabulary — `poll_until`, `once_across_workers`, `wait_for_smtp`, `send`, `container_exec`, `postconf`, `listening_ports`, `exit_code_within` and the rest. Imported by every test module but `test_sendmail.py` and `test_ruleset.py`, and by three of the four fixture modules. `file_missing` is defined and never called. |
+| `tests/helpers.py` | The shared vocabulary — `poll_until`, `once_across_workers`, `wait_for_smtp`, `send`, `container_exec`, `postconf`, `listening_ports`, `exit_code_within` and the rest. Imported by every test module but `test_sendmail.py` and `test_ruleset.py`, and by three of the four fixture modules. `file_missing` is the one that cannot be spelled with `container_exec`, which fails on a non-zero exit: asking whether a path is absent needs the exit code, not the output. |
 | `tests/requirements.txt` | Seven pinned packages: `dkimpy`, `docker`, `pytest`, `pytest-xdist`, `pyyaml`, `requests`, `testcontainers[mailpit]`. `dkimpy` is what satisfies `import dkim`, so grepping module names against this file looks like a miss when it is not; `pyyaml` is there for `test_ruleset.py` alone. |
 | `tests/fixtures/shared_network.py` | Session-scoped `shared_network`: a testcontainers `Network()` with a generated, labelled name — not a fixed one, so an interrupted run leaves nothing for the next one to collide with. |
 | `tests/fixtures/postfix.py` | Seven fixtures: `postfix_image`, `upgrade_from_image`, `postfix` and `_relay_pool` (session, the last being the per-configuration relay pool); `postfix_factory`, `postfix_shared` and `docker_volume` (function). Every relay gets `POSTFIX_relayhost=mailpit:1025`, set before the caller's env so a test can override it; readiness is an SMTP connection, not a log line. Reads `POSTFIX_RELAY_IMAGE` / `POSTFIX_RELAY_ARCH` / `POSTFIX_RELAY_IMAGE_PUBLISHED`, and the released image out of `tests/upgrade-from.Dockerfile`. |
@@ -256,9 +256,11 @@ would write differently, and it is what the suite passes with no edit to any
 one of the same name — pytest collects the second, the first one's assertions
 never run, and nothing says so. What `F` does *not* buy is worth knowing too:
 a fixture nobody requests is invisible to every pyflakes-family tool, a helper
-whose signature drifted needs pylint, and `file_missing` — the one dead helper
-the tree actually has — is seen at no ruff selection at all, `ALL` included.
-(#268, which asked for the gate, names all three as the thing it would catch.)
+whose signature drifted needs pylint, and a module-level function nobody calls
+is seen at no ruff selection at all, `ALL` included — pyflakes reports unused
+imports and unused locals, not that. (#268, which asked for the gate, names all
+three as the thing it would catch.) The tree had one of those, `file_missing`,
+until #305 gave it the caller it was written for.
 
 Widening is a deliberate edit here too, and it is not free: `E` is 62 `E501`s
 at ruff's 88 columns on a suite whose longest line has always been 102, `I`

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,8 +7,8 @@ unless they ask for more (issue #58).
 
 import re
 
-from tests.helpers import (container_exec, container_log, restart, send,
-                           wait_for_file, wait_for_log)
+from tests.helpers import (container_exec, container_log, file_missing, restart,
+                           send, wait_for_file, wait_for_log)
 
 MAIL_LOG_LINE = re.compile(r'^postfix/\w+\[\d+\]: ')
 TIMESTAMPED_MAIL_LOG_LINE = re.compile(r'^\d{4}-\d{2}-\d{2}T[\d:.+]+ \S+ postfix/\w+\[\d+\]: ')
@@ -81,7 +81,7 @@ def test_an_existing_rsyslog_conf_is_left_alone(postfix_factory, mailpit):
 
     assert 'Skipping /etc/rsyslog.conf generating' in container_log(relay)
     assert container_exec(relay, ["cat", "/etc/rsyslog.conf"]) == config
-    assert relay.exec(["test", "-e", "/var/log/mail.log"]).exit_code != 0
+    assert file_missing(relay, '/var/log/mail.log')
 
     send(relay, subject='logged as configured')
     mailpit.wait_for_message('logged as configured')


### PR DESCRIPTION
Closes #305

`tests/helpers.py` has defined `file_missing` since `aad5379` and nothing has ever called it. `CLAUDE.md` said so in two places, which made it documented rather than unknown, and #285's ruff gate will never report it at any selection -- pyflakes reports unused imports and unused locals, not a module-level function nobody calls, and `--select ALL` flags it only for a missing annotation and a missing docstring.

So the choice was between deleting it and giving it a caller, and the tree already had the site. `tests/test_logging.py` asserted

```python
assert relay.exec(["test", "-e", "/var/log/mail.log"]).exit_code != 0
```

which is `file_missing`'s body written out, between two lines that do go through the helpers:

```python
assert 'Skipping /etc/rsyslog.conf generating' in container_log(relay)
assert container_exec(relay, ["cat", "/etc/rsyslog.conf"]) == config
```

That is not a coincidence of style. `container_exec` fails on a non-zero exit, so absence is the one question it cannot be asked: you need the exit code, not the output, and dropping to a raw `.exec()` is the only way to get it. `file_missing` is exactly that gap -- which is why deleting it would have left the raw exec behind rather than removing anything.

The other two absence assertions in the tree cannot use it and are left alone: `tests/test_image.py` goes through `image_shell`, which runs in a throwaway container and takes no container argument.

`CLAUDE.md` moves with it in both places -- the `helpers.py` row, which called it never called, now says what it is for; and the Lint section, whose point was that a function nobody calls is invisible to every ruff selection, keeps that point without resting it on an example that is no longer true.

Tested on the built image: `tests/test_logging.py` is 14 passed, and `ruff check --no-cache --select F tests` is clean with la 0.16.6 the gate pins.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU