### PR TITLE
Say in the README what the shellcheck gate now reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,11 +933,13 @@ When a test fails, the log of the containers it used is part of the pytest
 output.
 
 `run` and `healthcheck` are shell rather than python, so the suite does not
-read them. Continuous integration runs shellcheck over both, and a pull
-request that introduces a shellcheck *error* in either is rejected:
+read them. Continuous integration runs shellcheck over both -- and over the
+session-start hook under `.claude/`, which ships nowhere but passes the same
+threshold anyway -- and a pull request that introduces a shellcheck *error*
+in any of them is rejected:
 
 ```bash
-shellcheck -S error run healthcheck
+shellcheck -S error run healthcheck .claude/hooks/session-start.sh
 ```
 
 That threshold is the whole gate. Warnings and notes below it are left


### PR DESCRIPTION
#321 added `.claude/hooks/session-start.sh` to the **ShellCheck** gate and moved `lint.yml` and `CLAUDE.md` with it. The README's *Testing* section did not move:

> Continuous integration runs shellcheck over both, and a pull request that introduces a shellcheck *error* in either is rejected:
> ```bash
> shellcheck -S error run healthcheck
> ```

Two files were updated, the third was not — the drift #295 and #301 were filed about, an hour later. It matters more here than in either of those: the README is the file a contributor reads first, and the command it prints is the one they copy, so it was quietly **narrower** than the gate it claims to reproduce.

## Verified

- the command the README now prints is character for character the one `lint.yml` runs (`diff` of the two lines: identical);
- running it with the shellcheck `lint.yml` pins — 0.11.0, fetched and checksummed the way the job fetches it — exits 0.

Documentation only: one paragraph and one code block. No workflow, script or test is touched.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
