### PR TITLE
Give a master run its own concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,15 @@ on:
 # A new push makes the images an in-flight run would produce obsolete, except
 # on master where the run publishes latest.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The group carries the commit on master, so a master run never queues
+  # behind another one. cancel-in-progress alone did not buy that: it
+  # protects a run that is already going, while github keeps at most one run
+  # pending per group and cancels that one the moment a third arrives. Three
+  # master runs of test.yml went that way on 5 September. This workflow's runs
+  # are shorter and have not been caught yet, which is timing rather than a
+  # difference -- and here the run that never starts is the one that never
+  # publishes.
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The group carries the commit on master, so a master run never queues
+  # behind another one. cancel-in-progress alone did not buy that: it
+  # protects a run that is already going, while github keeps at most one run
+  # pending per group and cancels that one the moment a third arrives. Three
+  # master runs of this workflow went that way on 5 September, before a single
+  # job of theirs started.
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/master' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 # The three jobs that run pytest are spelled out rather than written as one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,8 +406,14 @@ Notes a contributor will hit:
   but `master`. That exemption is deliberate — a cancelled `master` run is one
   that never published — and it is what makes two merges close together
   overlap, which is why **Publish latest** checks `master`'s head before it
-  moves the tag. `scan.yml` is the only one with a `schedule:`, and the only
-  one with no `pull_request` trigger.
+  moves the tag. `cancel-in-progress: false` did not buy that exemption on its
+  own: it protects a run that is already going, while github keeps at most one
+  run *pending* per concurrency group and cancels that one as soon as a third
+  arrives. Three `master` runs of `test.yml` were cancelled that way on
+  5 September, before a single job of theirs started. So the group itself
+  carries the commit on `master`, which is what keeps master runs from queueing
+  behind each other at all. `scan.yml` is the only one with a `schedule:`, and
+  the only one with no `pull_request` trigger.
 - Version skew: CI pins Python 3.13, and nothing pins a Python version locally.
   The Python dependencies are pinned exactly (`tests/requirements.txt`); their
   transitive dependencies are not, and there is no lock file, so a run can


### PR DESCRIPTION
Closes #<numéro de l'issue>

Both workflows set `cancel-in-progress` false on master, and CLAUDE.md records why: a cancelled master run is one that never published, and two merges close together are meant to overlap — which is what **Publish latest** checks master's head for. That setting does not deliver it. It protects a run that is already going, while github keeps at most one run *pending* per concurrency group and cancels that one as soon as a third arrives.

So master runs were being cancelled, just not in flight. Three runs of `test.yml` on 5 September, each with **0 jobs**:

```
run 273  3af3f93  merge of #289  cancelled 20:01:58
run 278  ccb3004  merge of #287  cancelled 20:06:58
run 293  c47aec8  merge of #302  cancelled 20:59:12
```

Each was queued behind the run before it and cancelled by the one after, before a single job started. Those three merge commits have no test run at all, and no junit for **Test Results** to republish. `ci.yml` carries the same group and the same exposure, where the run that never starts is the run that never publishes et never promotes `latest`; its runs are short enough that none has been caught yet, which is timing rather than a difference.

Putting the commit in the group on master is what actually stops master runs queueing behind each other: one group per commit, so there is never a pending run to cancel. Branches and pull requests keep the group they had, and keep cancelling in flight. `cancel-in-progress` stays as it was — on master it now has nothing to act on, and it still says what the intent is.

Verified: both workflow files still parse, `tests/test_ruleset.py` is **2 passed**, and the expression is the documented `&&` / `||` form, so a pull request ref renders the same group it renders today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tSWu9aw9bPwSNo8mZTgiU