### PR TITLE
Send the header the rule is written to strip

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,8 @@ import smtplib
 import pytest
 
 from tests.helpers import (container_exec, container_log, esmtp_features,
-                           listening_ports, postconf, send, smtp_connect, wait_for_log)
+                           listening_ports, postconf, send, send_raw, smtp_connect,
+                           wait_for_log)
 
 
 def test_postfix_variables_configure_main_cf(postfix_factory, mailpit):
@@ -195,13 +196,26 @@ def test_a_second_table_is_written_too(tables):
 
 
 def test_header_checks_read_the_table_that_was_written(tables, mailpit):
-    """The table is not only on disk, postfix acts on it."""
-    send(tables, recipients=('receiver@routed.example',), subject='checked headers',
-         body='body')
+    """The table is not only on disk, postfix acts on it.
+
+    "send" composes a message from Subject, From and To, so it cannot carry
+    the header the rule in TABLES is written to strip; asserting that header
+    is absent from a message that never had it passes on a relay with no
+    header_checks at all. "send_raw" is here for exactly this -- the test is
+    about the bytes -- and the second header is the control: something has to
+    survive, or a relay that dropped every header would pass this too.
+    """
+    send_raw(tables,
+             'Subject: checked headers\r\n'
+             'X-Internal-Note: not for the recipient\r\n'
+             'X-Application: invoice-service\r\n'
+             '\r\nbody\r\n',
+             recipients=('receiver@routed.example',))
 
     message = mailpit.wait_for_message('checked headers')
 
     assert 'x-internal-note' not in message['headers']
+    assert message['headers']['x-application'] == ['invoice-service']
 
 
 def test_every_domain_the_table_names_is_routed(tables, mailpit):


### PR DESCRIPTION
Closes #327.

## The test could not fail

`test_header_checks_read_the_table_that_was_written` asserts that `x-internal-note` is absent from a message that never carried it: `send` composes from `Subject`, `From`, `To` and the body, so there is no such header to strip.

## Measured, both ways

With `POSTFIX_header_checks` deleted from `TABLES` so postfix has no `header_checks` at all:

| | unmutated | mechanism removed |
| --- | --- | --- |
| the test as written | passes | **passes** |
| the test as it is now | passes | **fails** |

That is the whole argument. The `POSTMAP_` regexp-map path -- a table written from the environment and acted on by postfix -- is covered by this test alone; its neighbours check the file on disk and the `.db` beside it, not what postfix does with either.

## The change

`send_raw` already exists for the tests that are about the bytes rather than the parts, so the fix is to use it. The second header is a **control**: without one, a relay that dropped every header would pass this too -- the same vacuum one layer further out.

## Verified

`pytest` -> **246 passed, 2 skipped**, the count unchanged. `ruff check --no-cache --select F tests` clean. No script, workflow or image content is touched.

## How it was found

An eight-way parallel audit of the tree for statements that are false and promises nothing keeps. Four sibling gaps came out of the same pass and are not in this pull request -- the rsyslogd branch of `healthcheck` has no test, three of the four canonical-map overrides the README promises are unpinned, the trailing-whitespace guarantee for `_FILE` secrets is unpinned, and the `/etc/rsyslog.d` format property rests on an ordering nothing asserts. Each is one test, and each est sa propre décision.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
