### PR TITLE
Refuse a secret path that is a directory, and one that is empty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -706,8 +706,14 @@ changing any of them.
     variable; `printf -v "$var" '%s' "$(< "${!file}")"` is used because
     `$(< file)` drops trailing newlines, which a secret file is likely to end
     with and a password is unlikely to contain. An unreadable path exits 1
-    rather than starting a relay without the credential. The mechanism covers
-    exactly five prefixes — `POSTFIX_`, `POSTFIXMASTER_`, `POSTMAP_`,
+    rather than starting a relay without the credential, and so do the two
+    paths that get past `-r`: a directory, for which `test -r` is true while
+    `$(< some/dir)` is the empty string with a status of 0, and a file that is
+    readable and empty. Both would otherwise resolve to an empty value, which
+    nothing downstream objects to — an empty `POSTFIX_<name>` is how a
+    `Dockerfile` default is cleared on purpose — so the relay would come up
+    healthy with the thing it was told to read set to nothing. The mechanism
+    covers exactly five prefixes — `POSTFIX_`, `POSTFIXMASTER_`, `POSTMAP_`,
     `OPENDKIM_` and `POSTSRSD_`. `SASL_Passwds`, `POSTMASTER_ADDRESS` and the
     `RSYSLOG_*` variables have no `_FILE` form, and `tests/test_secrets.py`
     exercises the same five.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ secrets:
 
 The file wins when `<name>` is set as well, which is what happens whenever the
 variable is one the image gives a default to, and the container says so in its
-log. A path that cannot be read stops the container.
+log. A path that cannot be read stops the container, and so does one that
+names a directory or an empty file: an empty value would otherwise start a
+relay whose credential, domain or key is nothing at all.
 
 ### Relaying through another SMTP server
 

--- a/run
+++ b/run
@@ -136,10 +136,28 @@ secretsFromFiles()
         echo "$file points at '${!file}', which cannot be read." >&2
         exit 1
       fi
+      # "test -r" is true of a directory, and "$(< some/dir)" is the empty
+      # string with a status of 0 and nothing on stderr. So a path naming the
+      # secrets directory rather than the secret inside it -- the likeliest way
+      # to get this wrong -- would pass the check above and resolve to nothing.
+      if [ ! -f "${!file}" ] ; then
+        echo "$file points at '${!file}', which is not a file." >&2
+        exit 1
+      fi
 
       # $(< file) drops trailing newlines, which a secret file is likely to
       # end with and a password is unlikely to contain.
       printf -v "$var" '%s' "$(< "${!file}")"
+      # The same failure arriving by the last door left open: a file that is
+      # there, readable and empty. Nothing downstream would object -- an empty
+      # value is how a POSTFIX_ variable clears a Dockerfile default on purpose
+      # -- so the relay would come up healthy with the credential, domain or
+      # key it was told to read set to nothing. Clearing a default deliberately
+      # is what the plain variable is for and is untouched by this.
+      if [ -z "${!var}" ] ; then
+        echo "$file points at '${!file}', which is empty." >&2
+        exit 1
+      fi
       export "${var?}"
       # Unset so that the loops below don't also configure "<name>_FILE".
       unset "$file"

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -156,6 +156,40 @@ def test_the_file_variable_itself_configures_nothing(settings_from_files):
     assert 'submission/inet_FILE' not in container_stderr(settings_from_files)
 
 
+def test_a_path_that_is_a_directory_stops_the_container(postfix_factory):
+    """The likeliest way to get the path wrong: the secrets directory itself.
+
+    It passes the readability check -- "test -r" is true of a directory -- and
+    "$(< some/dir)" is the empty string with a status of 0, so without a check
+    of its own this starts a relay whose credential is the empty string.
+
+    The directory is made by putting the secret where it belongs, which is what
+    the mistake looks like in practice: the file is there, the variable names
+    the directory holding it.
+    """
+    relay = postfix_factory(env={'POSTMAP_sasl_passwd_FILE': '/run/secrets'},
+                            files={SECRET: SASL_PASSWD},
+                            wait_ready=False)
+
+    assert exit_code_within(relay, seconds=30) == 1
+    assert 'which is not a file' in container_stderr(relay)
+
+
+def test_an_empty_file_stops_the_container(postfix_factory):
+    """The same failure through the last door: readable, a file, and empty.
+
+    An empty value is how a POSTFIX_ variable clears a Dockerfile default on
+    purpose, so nothing downstream objects to one -- the relay would come up
+    healthy with the credential it was told to read set to nothing.
+    """
+    relay = postfix_factory(env={'POSTMAP_sasl_passwd_FILE': SECRET},
+                            files={SECRET: ''},
+                            wait_ready=False)
+
+    assert exit_code_within(relay, seconds=30) == 1
+    assert 'which is empty' in container_stderr(relay)
+
+
 def test_a_domain_list_from_a_file_is_watched_by_the_health_check(postfix_factory):
     relay = postfix_factory(env={'OPENDKIM_DOMAINS_FILE': '/run/secrets/dkim_domains'},
                             files={'/run/secrets/dkim_domains': "example.com\n"})


### PR DESCRIPTION
Closes #329.

`secretsFromFiles` guarded the path with `[ ! -r ]` and then read it with `$(< file)`. Two paths get past that guard and resolve to nothing: a directory, because `test -r` is true of one and `$(< some/dir)` is the empty string with a status of 0; and a file that is there, readable and empty.

Either way the relay came up, reported healthy, and relayed, with the credential, domain list or key it had been told to read set to the empty string. `POSTMAP_sasl_passwd_FILE=/run/secrets` -- the secrets directory rather than the secret in it -- is the likeliest way to get there.

Nothing downstream objects, and that is not an oversight either: an empty value is how a `POSTFIX_` variable clears a `Dockerfile` default on purpose, so an empty secret is indistinguishable from a deliberate one by the time it reaches `postconf`.

That is the failure mode the rest of `run` exists to refuse -- invariant 3 stops the container rather than relay without SRS, the DKIM refusals stop it rather than relay unsigned, invariant 7 refuses to hand over without a greeting. A missing credential is the same class and was the one door left open.

So: `[ ! -f ]` after the readability check, and a refusal on an empty value after the read. The "cannot be read" message is unchanged, because a test asserts it; the two new refusals say "which is not a file" and "which is empty". Clearing a variable deliberately is untouched.

**Verified against the unfixed `run` as well as the fixed one.** Without this change both new tests fail on

```
assert None == 1
 +  where None = exit_code_within(<container>, seconds=30)
```

-- `None`, not a wrong exit code: the container was still running after thirty seconds, which is the defect stated as une assertion. With it, `tests/test_secrets.py` is 12 passed, `shellcheck -S error` over the three scripts exits 0, and `ruff --select F` is clean.

The directory test builds the directory by putting the secret where it belongs and naming its parent, which is what the mistake looks like in practice -- no docker volume, so no teardown ordering to get wrong.

`README.md` and `CLAUDE.md` invariant 17 both said only that an unreadable path stops the container; both now say what else does.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU