### PR TITLE
Pin four promises that nothing pinned

### DIFF
--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -184,6 +184,23 @@ def test_stopped_saslauthd_is_unhealthy(relay_factory):
     assert 'clients cannot authenticate' in output.decode()
 
 
+def test_stopped_rsyslogd_is_unhealthy(relay_factory):
+    """The one daemon every relay starts, and the only branch of the check
+    that had no test.
+
+    Nothing about the mail stops: postfix keeps accepting, signing and
+    relaying, and the only difference is that none of it is written down --
+    which is the failure an operator finds by looking for a delivery that
+    left no line.
+    """
+    relay = relay_factory()
+
+    exit_code, output = healthcheck_after_stopping(relay, "rsyslogd")
+
+    assert exit_code == 1
+    assert 'relayed unlogged' in output.decode()
+
+
 def test_a_postfix_that_is_not_running_is_unhealthy(relay_factory):
     """The first thing the check looks at, and the one failure that means
     no mail is being accepted at all."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -66,6 +66,35 @@ def test_rsyslog_d_configuration_is_included(postfix_factory, mailpit):
     assert wait_for_file(relay, '/var/log/from-include.log', 'status=sent')
 
 
+def test_an_include_keeps_the_rsyslog_default_format(postfix_factory, mailpit):
+    """RSYSLOG_TIMESTAMP does not reach a .conf file of your own.
+
+    It is the same relay as the test above, read for its format rather than
+    its content: the container log has no timestamps here, the include's
+    file does. The property is an ordering -- "run" emits the include above
+    the $template pair, and a directive applies only to actions written
+    after it -- so tidying the include down next to the other file actions
+    would make the README's sentence false with nothing else failing. That
+    tidy-up would look like it was tightening invariant 12, which is about
+    the same pair one line further up.
+    """
+    relay = postfix_factory(
+        files={'/etc/rsyslog.d/99-test.conf': 'mail.* /var/log/from-include.log\n'})
+
+    send(relay, subject='format from an include')
+    mailpit.wait_for_message('format from an include')
+    assert wait_for_file(relay, '/var/log/from-include.log', 'status=sent')
+
+    included = [line for line in
+                container_exec(relay, ["cat", "/var/log/from-include.log"]).splitlines()
+                if 'postfix/' in line]
+
+    assert included, "the include logged nothing to read a format from"
+    assert all(TIMESTAMPED_MAIL_LOG_LINE.match(line) for line in included), included[:3]
+    assert all(MAIL_LOG_LINE.match(line) for line in postfix_log_lines(relay)), \
+        "the container log should still be the untimestamped one"
+
+
 def test_an_existing_rsyslog_conf_is_left_alone(postfix_factory, mailpit):
     """A mounted /etc/rsyslog.conf replaces the generated one.
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -111,6 +111,28 @@ def test_the_file_wins_when_the_variable_is_also_set(postfix_factory):
     assert 'POSTMAP_sasl_passwd is also set' in container_log(relay)
 
 
+def test_the_whitespace_a_secret_file_ends_with(postfix_factory):
+    """Trailing newlines go, however many; a trailing space stays.
+
+    Both halves rest on one line of "run" -- printf -v "$var" '%s'
+    "$(< "${!file}")" -- and every other secret file in this module ends in
+    exactly one newline and no space, which is the single case a correct
+    reader and a whitespace-stripping one agree on. The asymmetry is the
+    half that bites: an editor that leaves a blank line at the end is
+    harmless, and a password with a space appended fails to authenticate
+    with nothing in the log to say why, so a tidy-up that trimmed both
+    would look like an improvement.
+    """
+    relay = postfix_factory(
+        env={'POSTMAP_sasl_passwd_FILE': SECRET},
+        files={SECRET: f"{UPSTREAM} {USER}:{PASSWORD} \n\n\n"})
+
+    # The POSTMAP loop writes the resolved value with echo, so the table is
+    # the value plus the one newline echo adds -- no others, and the space.
+    assert container_exec(relay, ["cat", "/etc/postfix/sasl_passwd"]) == \
+        f"{UPSTREAM} {USER}:{PASSWORD} \n"
+
+
 def test_a_path_that_cannot_be_read_stops_the_container(postfix_factory):
     relay = postfix_factory(env={'POSTMAP_sasl_passwd_FILE': '/run/secrets/not_mounted'},
                             wait_ready=False)

--- a/tests/test_srs.py
+++ b/tests/test_srs.py
@@ -135,6 +135,35 @@ def test_user_supplied_canonical_maps_are_kept(postfix_factory):
     assert postconf(relay, 'recipient_canonical_maps') == 'tcp:127.0.0.1:10002'
 
 
+def test_every_canonical_setting_the_readme_names_can_be_overridden(postfix_factory):
+    """Four settings are promised, and each has its own guard in srsConfig.
+
+    The test above sets one of them, so removing any of the other three
+    guards -- which is one line each, and CLAUDE.md invariant 2 exists
+    because they look removable -- silently overwrote a user's value with
+    the suite still green. The classes are the pair worth having here
+    rather than the maps alone: they are what decides whether the visible
+    From: is rewritten along with the envelope, and the answer the image
+    picked for them is deliberate.
+    """
+    supplied = {
+        'POSTFIX_sender_canonical_maps': 'hash:/etc/postfix/sender_canonical',
+        'POSTFIX_sender_canonical_classes': 'envelope_sender,header_sender',
+        'POSTFIX_recipient_canonical_maps': 'hash:/etc/postfix/recipient_canonical',
+        'POSTFIX_recipient_canonical_classes': 'envelope_recipient',
+    }
+    relay = postfix_factory(env={
+        'POSTSRSD_SRS_DOMAIN': SRS_DOMAIN,
+        'POSTMAP_sender_canonical': '@example.com noreply@example.com',
+        'POSTMAP_recipient_canonical': '@example.com inbox@example.com',
+        **supplied,
+    })
+
+    for variable, value in supplied.items():
+        setting = variable[len('POSTFIX_'):]
+        assert postconf(relay, setting) == value, setting
+
+
 @pytest.fixture
 def shared_srs_relay(postfix_shared):
     """Rewriting relay shared by the tests that only read it back."""


### PR DESCRIPTION
Four documented behaviours had no test. Each is one test, one commit, and each was measured **both ways** — it passes on the tree, and it fails when the mechanism it names is removed. A test that has not been seen to fail is a comment.

| commit | promise | mutation | result |
| --- | --- | --- | --- |
| `Test the one health check branch that had none` | `healthcheck` fails when rsyslogd is gone | that line replaced by a comment | new test **fails**; it was the only daemon branch with no test |
| `Pin all four canonical settings…` | four `POSTFIX_*canonical*` overrides survive SRS | the `sender_canonical_classes` guard removed | new test **fails**, the existing one **passes** |
| `Pin what a secret file may end with` | trailing newlines ignored, trailing space kept | `printf -v … "$(< file)"` → `read -r` | new test **fails**, the module's other ten **pass** |
| `Pin the format an /etc/rsyslog.d file keeps` | an include keeps rsyslog's default format | include moved below the `$template` pair | new test **fails**; one other test also fails, see below |

## The last one, precisely

The reordering is **not** silent, and it is worth saying so: `test_messages_are_forwarded_to_a_remote_syslog_server` fails under it too. But it fails by coincidence — it builds its receiver from an `/etc/rsyslog.d` file and asserts the sending container's id appears in what arrived; under the mutation that receiver's own action inherits the no-timestamp template, which drops the hostname the assertion looks for. It reports a remote-forwarding failure, one feature away from what broke. Nothing named the property the README states.

Two earlier attempts at that mutation broke the script rather than the ordering — the include lives inside a heredoc — and took a dozen tests down with them. Those runs measured nothing; the numbers above are from the one that holds.

## Why one pull request

Four tests, four independent commits, one concern: promises the docs make that the suite did not keep. Each commit stands alone if you would rather take them separately.

## Verified

`pytest` → **250 passed, 2 skipped**, against 246 before. `ruff check --no-cache --select F tests` clean. No script, workflow or image content is touched — only `tests/`.

## Where they came from

An eight-way parallel audit of the tree for statements that are false and promises nothing keeps; 43 raw findings, of which these four and the `header_checks` one already merged were the ones that survived checking against the tree by hand.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
