### PR TITLE
Say what the verify jobs check, now that latest waits for them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,8 @@ Dockerfile ──FROM──> debian:trixie-<date>-slim
     ├──COPY──> run          -> /root/run          <- CMD
     └──COPY──> healthcheck  -> /root/healthcheck  <- HEALTHCHECK
 
-.dockerignore excludes .git, README.md, LICENSE, tests, pytest.ini,
-                     CLAUDE.md, .claude
+.dockerignore excludes .git, README.md, SECURITY.md, LICENSE, tests,
+                     pytest.ini, CLAUDE.md, .claude
     => nothing under tests/, and neither pytest.ini nor this document, can
        invalidate the build cache
 


### PR DESCRIPTION
The header of **Verify Published Image (amd64)** still described the pipeline as it was before #272:

```
# Only where there was a publication to check: the step above pushes latest
# on master and nowhere else. Nothing is rolled back if this fails -- the
# tag is already out -- but a red check on master is the difference between
# knowing and not.
```

Both halves stopped being true when `c413ee7` moved the tag behind these jobs, and that commit rewrote five other comments in this file without touching this one. So did `07ba83f`, the commit whose whole job was correcting five CI comments that described a tree that had moved on; it edited the arm64 twin's header, immediately below, and left this.

- **"the step above pushes latest"** -- it does not, and has not since `c413ee7`. docker_meta carries `latest=false` and the build pushes its tags: the branch name and `sha-<commit>`. The step's own comment a hundred lines up says so outright -- *"'latest' is not among these tags and is never written here"*.
- **"the tag is already out"** -- it is not. `promote` has `needs: [docker, verify_published_amd64, verify_published_arm64]`, so a red check here means the tag never moves.

Which inverts what the comment is for. It told a reader that a failure here is informational because the damage is done, when the point of #272 is the opposite: this check is what stands between a broken image and the tag users pull. `CLAUDE.md` and `README.md` were both corrected at the time -- "the tag stays where it was", "an image that does not come up leaves `latest` where it was" -- so the workflow was contradicting the two documents and its own build step.

The replacement also says what the old sentence got at clumsily, that the job is master-only because that is the publication it is about, without claiming master is the only ref that pushes anything: a branch pushes its own tag, and a tag ref copies the release tags onto an image master already published. Neither is what these jobs pull.

Comment only. `tests/test_ruleset.py` passes and `ci.yml` parses.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU