### PR TITLE
Name the root process the shipped configuration puts on the mail path

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,19 +451,41 @@ actually handles mail is not root:
 | --- | --- |
 | the start-up script, `master`, `rsyslogd` | `root` |
 | `saslauthd`, when `SASL_Passwds` is set | `root` |
-| `smtpd`, `cleanup`, `qmgr`, `smtp`, the rest of postfix | `postfix`, chrooted into `/var/spool/postfix` |
+| `local`, `virtual`, on the deliveries below | `root`, not chrooted |
+| `smtpd`, `cleanup`, `smtp`, the rest of postfix | `postfix`, chrooted into `/var/spool/postfix` |
 | `opendkim` | `opendkim` |
 | `postsrsd` | `postsrsd`, chrooted into `/var/lib/postsrsd` |
 
-As the relay ships, the root processes supervise and log; they do not parse
-untrusted input. Setting `SASL_Passwds` adds one that does: `saslauthd` runs as
-root and checks the username and password an SMTP client sent, through PAM.
+Two entries in that table are worth reading twice. The chroot is what
+`master.cf` asks for per service, so `qmgr`, `proxymap`, `proxywrite` and
+`postlog` run as `postfix` without one; and the root processes are not all
+supervisors.
+
+`local(8)` is the one that is there as the image ships. Debian's `master.cf`
+gives it and `virtual(8)` the only two `n` entries in the unprivileged column,
+so `master` runs them as root rather than as `postfix`, and unchrooted. The
+default `mydestination=localhost` puts them on the path: an address at
+`localhost` is a destination this relay accepts for itself, so any client the
+default `mynetworks=0.0.0.0/0` lets in can have a message delivered by a root
+process without authenticating. Narrowing `mynetworks`, which
+[Securing the relay](#securing-the-relay) recommends, does not close that --
+an authorized *destination* is authorized whoever the client is.
+
+Setting `POSTFIX_mydestination=` empty is what does: an address at `localhost`
+is then a destination like any other, handed to the unprivileged chrooted
+`smtp` client instead. Measured both ways on the built image, with a message
+from outside the container to `root@localhost`: as shipped,
+`relay=local, status=sent`; with `mydestination` empty, no `local` process
+runs at all and the same message leaves through `smtp`. That is what a relay
+which delivers nothing locally wants, and it is not the default.
+
+Setting `SASL_Passwds` adds the other: `saslauthd` runs as root and checks the
+username and password an SMTP client sent, through PAM.
 That is what it is for, and it is why the directory holding its socket is
 created `root:sasl` mode `710` rather than left at the world-writable mode
 `saslauthd` gives the socket itself -- an unauthenticated password check
 reachable by every uid in the container would be an oracle for guessing at the
-passwords. Nothing to configure, but worth knowing before deciding what a
-relay of yours may do.
+passwords.
 
 Either way, most of what docker grants the container by default is unused and
 can be taken away:

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -15,7 +15,8 @@ import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
-from tests.helpers import (esmtp_features, image_run, listening_ports, postconf,
+from tests.helpers import (container_exec, esmtp_features, image_run, listening_ports,
+                           postconf,
                            process_running, send, wait_for_log)
 
 # A next hop whose certificate is signed by a CA of our own, so that trusting
@@ -121,6 +122,27 @@ def test_the_relay_is_open(postfix):
     """Documented, and the reason the README says not to expose the container."""
     assert postconf(postfix, 'mynetworks') == '0.0.0.0/0'
     assert postconf(postfix, 'mydestination') == 'localhost'
+
+
+def test_which_postfix_daemons_master_keeps_privileged(postfix):
+    """The README's "What runs as root" table, from master.cf rather than prose.
+
+    Column four is the unprivileged column: "n" means master runs the service
+    as root instead of as mail_owner, and Debian sets it on local(8) and
+    virtual(8) alone. Column five is the chroot, which is "n" for those two and
+    for qmgr and proxymap. Both are facts about the master.cf the base image
+    ships, so a suite bump can change them under a section of the README whose
+    whole purpose is to say what a relay of yours may be allowed to do.
+    """
+    services = [line.split() for line in
+                container_exec(postfix, ["postconf", "-M"]).splitlines() if line.strip()]
+
+    privileged = sorted({s[0] for s in services if s[3] == 'n'})
+    unchrooted = sorted({s[0] for s in services if s[4] == 'n'})
+
+    assert privileged == ['local', 'virtual'], privileged
+    assert unchrooted == ['local', 'postlog', 'proxymap', 'proxywrite', 'qmgr',
+                          'virtual'], unchrooted
 
 
 def test_nothing_is_signed(postfix, mailpit):


### PR DESCRIPTION
*What runs as root* said the root processes supervise and log and do not parse untrusted input, with `saslauthd` named as the one exception you can turn on. There is a second exception, and it needs no turning on.

## `local(8)`

Debian's `master.cf` gives `local` and `virtual` the only two `n` entries in the **unprivileged** column, so `master` runs them as root rather than as `postfix`, and unchrooted. The image ships `mydestination=localhost`, which puts them on the path, et `mynetworks=0.0.0.0/0`, qui laisse entrer n'importe qui.

Measured on the built image, a message sent from **outside** the container with no authentication:

```
postfix/local[238]: E36F0924F8: to=<root@localhost>, relay=local, delay=0.01,
                    dsn=2.0.0, status=sent (delivered to mailbox)
```

Narrowing `mynetworks`, which *Securing the relay* recommends, does not close it — an authorized **destination** is authorized whoever the client is. What does close it is `POSTFIX_mydestination=` empty, and the README says so because it was measured: the same message then leaves through the unprivileged chrooted `smtp` client and no `local` process runs at all.

This matters more here than a wording slip elsewhere. The section exists to justify the capability set it then recommends dropping, so it is exactly where a reader decides what a relay of theirs may be allowed to do.

## And `qmgr` was not chrooted

The same table listed `qmgr` among the daemons "chrooted into `/var/spool/postfix`". The chroot is column five of `master.cf`, and it is `n` for `qmgr`, `proxymap`, `proxywrite` and `postlog` as well as for les deux ci-dessus. `qmgr` does drop to `postfix`, so only the chroot half was wrong.

## Pinned, because it is the base image's fact and not ours

Both lists come from the `master.cf` Debian ships, which a suite bump can change under a section whose whole subject is what a relay may be allowed to do. `tests/test_defaults.py` now derives both from `postconf -M`.

Written from the image rather than from the README: the first version of that test asserted the list I expected and **failed**, because `postlog` is unchrooted too. The list in the tree is the measured one.

## Verified

`pytest` → **253 passed, 2 skipped**. `ruff check --no-cache --select F tests` clean. `run`, the workflows and the image are untouched — this is `README.md` and one test.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
