### PR TITLE
Say what a failed verification actually costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,13 +889,18 @@ built by buildx rather than by the daemon the suite uses, so a push to `master`
 publishes the image under its commit before it publishes it under `latest`:
 the pushed image is pulled back on `amd64` and on `arm64` -- the way anyone
 else pulls it -- and the same smoke tests are run against it. Its manifest is
-read too, and the push fails if it does not list all three architectures that
+read too, and the check fails if it does not list all three architectures that
 were built: each half of the check pulls the entry for its own architecture,
 so the one with no runner is only visible there. Only then is `latest` moved
-onto that image. It is the only check that looks at what a push to `master`
-publishes, and it runs before anyone can pull it: an image that does not come
-up leaves `latest` where it was. The upgrade tests above reach the registry
-too, but for a released tag, which is a different question.
+onto that image.
+
+What a failure costs is worth being exact about, because the image is on the
+registry before any of this runs: the build pushed it under the commit, and
+that tag stays. What waits is `latest`, which is moved afterwards and only on
+the strength of these checks, so an image that does not come up leaves the tag
+everyone pulls where it was. That is what makes them the only checks looking
+at what a push to `master` publishes. The upgrade tests above reach the
+registry too, but for a released tag, which is a different question.
 
 A release is the same image again rather than another one. Pushing a version
 tag builds nothing: the commit it names was on `master` first, so its image is


### PR DESCRIPTION
Two sentences in the README's *Testing* section were mine, from #272, and both were wrong about the arrangement that change introduced — in the direction that flatters it.

| as written | what is true |
| --- | --- |
| "**the push fails** if it does not list all three architectures that were built" | The push has already happened. **Build Image** pushes the commit tags, and the verification jobs declare `needs: docker` and read the digest *that push produced*. What fails is the check, and what that costs is that **Publish latest** does not run. |
| "it runs **before anyone can pull it**" | Anyone can pull it. The image is on the registry under `sha-<commit>` and its digest from the moment the build finishes — which is exactly what makes pulling it back a real pull rather than a look at a local build. What waits for the checks is `latest`. |

A reader deciding how much these checks buy them would have been told they gate the publication, when they gate the tag. That is the more useful thing to say anyway, and the paragraph now says it: the image is out under its commit either way, and `latest` is what stays put when it does not come up.

`CLAUDE.md` already has the same arrangement written correctly — *"what the build pushes is reachable under `sha-<commit>` and its digest, `latest` is not written by the build at all"* — so only the README moves.

## Verified

Against `.github/workflows/ci.yml` at this commit rather than from memory: the job graph is `docker` → `verify_published_amd64` and `verify_published_arm64` → `promote`; the master build step has `push: true` with docker_meta's tags under `flavor: latest=false`; the verify jobs read `needs.docker.outputs.digest`, which exists only because that push succeeded.

Documentation only — one paragraph. No test covers README prose, so `tests/test_ruleset.py` et `ruff` sont les seules portes concernées, et les deux passent.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
