### PR TITLE
Assert the ways the ruleset can stop gating and still parse

### DIFF
--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -56,8 +56,18 @@ def test_every_required_check_names_a_job_that_exists():
 
 def test_the_ruleset_still_gates_the_default_branch():
     """A re-export made after fiddling in the web UI can bring back a file
-    that records a gate which does not gate."""
+    that records a gate which does not gate.
+
+    Every way it can stop gating while still parsing, so that the file being
+    re-importable is not mistaken for it being the same file: disabled or in
+    "evaluate" mode, aimed at something other than the default branch, the
+    default branch excluded again underneath, opened to a bypass actor, or the
+    one rule replaced by a type that gates nothing.
+    """
     recorded = ruleset()
+    assert recorded["target"] == "branch"
     assert recorded["enforcement"] == "active"
     assert recorded["conditions"]["ref_name"]["include"] == ["~DEFAULT_BRANCH"]
+    assert recorded["conditions"]["ref_name"]["exclude"] == []
     assert recorded["bypass_actors"] == []
+    assert [r["type"] for r in recorded["rules"]] == ["required_status_checks"]


### PR DESCRIPTION
`test_the_ruleset_still_gates_the_default_branch` says in its docstring that it exists because *"a re-export made after fiddling in the web UI can bring back a file that records a gate which does not gate"*. It checked three fields: `enforcement`, the include list and `bypass_actors`. A re-export can be a gate that does not gate in three more ways, all of which parse and all of which the test passed.

Each is now asserted, and each was checked by doctoring the file and watching the test fail rather than by reading it:

| doctored field | result |
| --- | --- |
| `target = "tag"` | 1 failed |
| `enforcement = "evaluate"` | 1 failed |
| `ref_name.exclude = ["~DEFAULT_BRANCH"]` | 1 failed |
| `rules[0].type = "deletion"` | 2 failed |

and the unmodified file is 2 passed.

The `exclude` one is the least obvious and the most plausible: a ruleset can include the default branch and exclude it underneath, which reads as gating and does not.

The rule-type one overlaps with `required_contexts()`, whose "expected one required_status_checks rule" assertion is why that mutation fails twice -- it is asserted here as well because that helper's job is to read the contexts, not to state what the file must contain, and a reader looking for the gate's shape should find it in the test named after it.

`target` is asserted for completeness rather than because a bad export is likely: a tag ruleset cannot carry a `required_status_checks` rule, so github's exporter would not produce that file. It costs one line et il fails if the assertion is ever wrong.

This is the test #277 is about to make load-bearing: that issue asks for the file to be imported and re-exported, which is exactly the round trip the docstring names.

No new dependency and no container -- still the one module that runs without a docker daemon. `ruff --select F,B` is clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XkYQc1Eh7QpuXBmkPbWEU