### PR TITLE
Replace four stale counts and two half-right commit citations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -89,14 +89,16 @@ jobs:
   # which is a defect that survives review and then bites once per process
   # rather than once per call. What the two leave out is not small -- E501 would
   # impose a line length the suite has never had, I001 would reorder the imports
-  # of seventeen files, and "ruff format" would rewrite most of them -- and none
-  # of it is a defect today. The measured cost of each is in #304.
+  # of most of the files that have any, and "ruff format" would rewrite most of
+  # them -- and none of it is a defect today. The measured cost of each is in
+  # #304.
   #
   # The selection is written out rather than inherited from ruff's default,
-  # because that default is a moving target: on this tree, unchanged, it is two
-  # findings under ruff 0.15.8 and twenty-eight under 0.16.6. "--select F" is
-  # the same on both. Pinning the version is only half of not surprising an
-  # unrelated pull request; naming the rules is the other half.
+  # because that default is a moving target: on this tree, unchanged, it finds a
+  # couple of things under ruff 0.15.8 and more than ten times as many under
+  # 0.16.6, while "--select F,B" is clean on both. Pinning the version is only
+  # half of not surprising an unrelated pull request; naming the rules is the
+  # other half.
   #
   # --no-cache keeps ruff from leaving a .ruff_cache/ in the checkout, which is
   # the reason the binary is unpacked into RUNNER_TEMP as well: the tree a step

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,16 +255,18 @@ code someone would write differently, and they are what the suite passes with
 no edit to any `.py` file. `B` was added by #304 because it costs nothing here
 and buys `B006`, a mutable default argument — a defect that survives review and
 then bites once per process rather than once per call. `B` is the bugbear
-linter and not every code starting with that letter: measured with `--ignore-noqa`,
-`--select B` does not reach the `BLE001` below, which `--select BLE` does. The one worth naming is `F811`, a test function replaced by a later
-one of the same name — pytest collects the second, the first one's assertions
-never run, and nothing says so. What `F` does *not* buy is worth knowing too:
-a fixture nobody requests is invisible to every pyflakes-family tool, a helper
-whose signature drifted needs pylint, and a module-level function nobody calls
-is seen at no ruff selection at all, `ALL` included — pyflakes reports unused
-imports and unused locals, not that. (#268, which asked for the gate, names all
-three as the thing it would catch.) The tree had one of those, `file_missing`,
-until #305 gave it the caller it was written for.
+linter and not every code starting with that letter: measured with
+`--ignore-noqa`, `--select B` does not reach the `BLE001` below, which
+`--select BLE` does. The one worth naming is `F811`, a test function replaced
+by a later one of the same name — pytest collects the second, the first one's
+assertions never run, and nothing says so. What `F` does *not* buy is worth
+knowing too: a fixture nobody requests is invisible to every pyflakes-family
+tool, a helper whose signature drifted needs pylint, and a module-level
+function nobody calls is seen at no ruff selection at all, `ALL` included —
+pyflakes reports unused imports and unused locals, not that. (#268, which
+asked for the gate, names all three as the thing it would catch.) The tree had
+one of those, `file_missing`, until #305 gave it the caller it was written
+for.
 
 Widening past those two is a deliberate edit and it is not free: `E` imposes a
 line length the suite has never had, `I` reorders the imports of most of the
@@ -274,9 +276,11 @@ measured menu — every selection with its finding count, so the next person nee
 not re-derive it — is #304. Deliberately not repeated here: those counts move
 with every merge, and what they are being used to say does not. The selection
 is written out rather than left to ruff's default for the same reason the
-version is pinned: on this tree, unchanged, the default is two findings under
-ruff 0.15.8 and twenty-eight under 0.16.6, while the named rules are the same on
-both. Nothing bumps that pin either.
+version is pinned: on this tree, unchanged, that default finds a couple of
+things under ruff 0.15.8 and more than ten times as many under 0.16.6, while
+`F,B` is clean on both. A ratio rather than two counts, for the reason the
+sentence above gives: it is the gap that is being pointed at, and the gap does
+not move. Nothing bumps that pin either.
 
 There is still no linter *configuration* anywhere in the repo (no
 `.shellcheckrc`, `.hadolint.yaml`, `pyproject.toml`, `setup.cfg`, `tox.ini`,
@@ -777,7 +781,8 @@ changing any of them.
     a server certificate against, so the two security levels that authenticate
     the next hop cannot be used at all. `CAfile` and not `CApath`, because the
     client opens it while still root, before chrooting into the queue, which a
-    directory of hashed links would not survive. (commit `8e8e89c`)
+    directory of hashed links would not survive. (commit `8e8e89c` for the
+    protocols, `d8f57a0` for the trust store)
 
 24. **`${v//__/\/}` replaces every `__`, not the first.** The README promises
     "all double `__` symbols"; the code used to substitute only the first
@@ -786,17 +791,16 @@ changing any of them.
     documented rule rather than to rely on that. (commit `90839a0`)
 
 25. **`perl` and `openssl` are named explicitly in the `Dockerfile` apt list.**
-    `perl` lands in
-    the image anyway today, but only through opendkim-tools' `perl:any`
-    dependency, which `perl-base` cannot satisfy — while `qshape`, a perl
-    script shipped in the postfix package, is named in no postfix dependency at
-    all. Naming perl adds no package and no bytes now, and keeps a correct
-    narrowing of that opendkim dependency from taking `qshape` down on a
-    routine base bump. `tests/test_qshape.py` exists for exactly this.
+    `perl` lands in the image anyway today, but only through opendkim-tools'
+    `perl:any` dependency, which `perl-base` cannot satisfy — while `qshape`,
+    a perl script shipped in the postfix package, is named in no postfix
+    dependency at all. Naming perl adds no package and no bytes now, and keeps
+    a correct narrowing of that opendkim dependency from taking `qshape` down
+    on a routine base bump. `tests/test_qshape.py` exists for exactly this.
     `openssl` is named for the same class of reason: `run` uses `openssl pkey`
     to refuse a DKIM key it cannot read, so the binary is a dependency of the
     entrypoint rather than of any package the image happens to install.
-    (commit `2e420c4`)
+    (commit `2e420c4` named perl, `4a44c60` openssl)
 
 26. **The image has no `ENTRYPOINT`, only `CMD ["/root/run"]`**, which is what
     makes `docker run --rm <image> mkpasswd …` work as the README documents,

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -91,8 +91,8 @@ def test_the_documented_default_is_in_the_image(environment, name, value):
 def test_the_image_sets_no_other_variables(environment):
     """A default nobody asked for configures every deployment silently.
 
-    PATH and DEBIAN_FRONTEND come from the base image and the build; the
-    rest of the environment is the list above and nothing else.
+    PATH is the base image's; the rest of the environment is the list
+    above and nothing else.
     """
     unexpected = set(environment) - {name for name, _ in DEFAULT_ENVIRONMENT} - {'PATH'}
 

--- a/tests/test_qshape.py
+++ b/tests/test_qshape.py
@@ -13,5 +13,6 @@ from tests.helpers import container_exec
 def test_qshape_reports_on_the_queues(postfix):
     output = container_exec(postfix, ["qshape"])
 
-    # The header row of an empty deferred queue summary.
+    # The totals row of an empty summary -- the header row is the age
+    # buckets. With no queue named, qshape reports on incoming and active.
     assert "TOTAL" in output


### PR DESCRIPTION
Six statements in the tree that no longer describe it. None changes what anything does; each is a sentence the next reader would take as measured fact.

### Counts that moved

| Where | Says | Measured now |
| --- | --- | --- |
| `lint.yml` | ruff's default is "twenty-eight under 0.16.6" | **29** — 17 `I001`, 5 `SIM117`, 5 `ISC004`, one `UP032`, one `UP031` |
| `lint.yml` | `I001` "would reorder the imports of seventeen files" | **19 findings across 18 files**, of the 24 in `tests/` that have imports |
| `CLAUDE.md` | the same twenty-eight | same 29 |

`CLAUDE.md` carries that number three paragraphs after telling the reader that counts move with every merge and are better replaced by what they were being used to say. Both files now say it that way — "a couple of things under 0.15.8 and more than ten times as many under 0.16.6", "most of the files that have any" — which is what the sentences were for: the default is a moving target between two releases where the named rules are not.

Measured on this tree, at the version `lint.yml` pins and the one before it:

```
ruff 0.15.8   default: 2 errors     --select F,B: All checks passed!
ruff 0.16.6   default: 29 errors    --select F,B: All checks passed!
```

`lint.yml` also said `--select F` where the gate has been `F,B` since #304.

### Commits cited for a pair when they did one of it

Both invariants pair two decisions and cite one commit, so half of "read the linked commit before changing any of them" pointed at a commit that does not mention the thing.

- **Invariant 23** cites `8e8e89c`, which added `POSTFIX_inet_protocols=ipv4`. The trust store half is `d8f57a0`, *Point postfix at the trust store the image already ships*.
- **Invariant 25** cites `2e420c4`, which added `perl`. The openssl half is `4a44c60`, *Refuse a DKIM key that is there but cannot be read*.

### Two test comments

`tests/test_image.py` says "PATH and DEBIAN_FRONTEND come from the base image and the build". `DEBIAN_FRONTEND` appears nowhere in the tree — not in the `Dockerfile`, not in the base image's environment, not in the built image's — which is why the assertion below it excludes `PATH` alone and passes.

`tests/test_qshape.py` calls `TOTAL` the header row of a deferred queue summary. It is the totals row (the header row is the age buckets), and the test runs `qshape` with no argument, whose default is the incoming and active queues — `my @qlist = qw(incoming active);` in qshape itself.

### Verification

- `pytest tests/test_qshape.py tests/test_image.py` — 38 passed
- `ruff check --no-cache --select F,B tests` — clean, at both 0.15.8 and 0.16.6
- `shellcheck -S error run healthcheck .claude/hooks/session-start.sh` — clean
- image environment read back with `docker inspect`, qshape's default read out of the script in the built image

Some rewrapping comes with it: three paragraphs had lines running to 142 columns where the file wraps at 79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
