### PR TITLE
Ignore the last directory a documented test run leaves behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
 __pycache__/
+.pytest_cache/
 junit/
 venv/


### PR DESCRIPTION
3089d60 added `junit/` and 97a199d added `venv/`, both because the README's Testing section produces them at the repository root and a `git add -A` afterwards stages them. `.pytest_cache/` is the third and was missed: `pytest.ini` sets no `cache_dir`, so pytest writes its cache into the rootdir like the other two, and it is neither tracked nor ignored today.

Deliberately **not** added to `.dockerignore`, for the reason 97a199d already measured and wrote down: buildkit syncs only what an instruction references rather than tarring the context, so with 77M of virtualenv at the root that build still reported `transferring context: 24.69kB`. The exclusion buys nothing here either, and CLAUDE.md would then claim a saving that does not exist.

### Verification

- `git check-ignore -v .pytest_cache/v/cache/lastfailed` reports `.gitignore:3`.
- `git status --porcelain` is empty with the directory present.

No docker daemon in the environment this was written in, which is why the `.dockerignore` half is left to the measurement above rather than repeated.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcbrLzYNHbU5m8iNUGqaJS