### PR TITLE
Rebuild the DKIM record for a key restored without its .txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,15 @@ jobs:
   docker:
     name: "Build Image"
     runs-on: ubuntu-latest
+    # Backstop, the way every job in test.yml and lint.yml carries one. Without
+    # it a job that hangs runs to github's default of six hours, and this is the
+    # one required check that reaches for the network on three architectures: a
+    # buildx that never returns would hold a pull request for those six hours
+    # and, on master, keep the two verification jobs and the promotion waiting
+    # behind it. 45 is what "Pytest (arm/v7, emulated)" is given for building
+    # one emulated architecture; this builds two and pushes them, and takes
+    # about half a minute when the layer cache holds.
+    timeout-minutes: 45
     outputs:
       # What the jobs below pull and what "Publish latest" promotes. A digest
       # rather than a tag: it names this run's image and cannot be moved by

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -46,6 +46,9 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    # Backstop. Two API calls, and nothing here should ever sit for github's
+    # default six hours.
+    timeout-minutes: 5
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -18,6 +18,9 @@ jobs:
   test-results:
     name: Test Results
     runs-on: ubuntu-latest
+    # Backstop. It downloads two artifacts and publishes a check: measured at
+    # 17-51s over the last five runs.
+    timeout-minutes: 10
     if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
 
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,6 +400,9 @@ Notes a contributor will hit:
   for the emulated one). The job timeouts are backstops: a cancelled job skips
   the upload step, so the bound expected to fire is the step's. Every wait in
   the suite is bounded, so overrunning it means something is stuck, not slow.
+  Every job in the repository carries one — thirteen of thirteen — which is
+  not a style rule: a job without it runs to github's default of six hours,
+  and the three that had none included **Build Image**, a required check.
 - **One action is pinned to a commit**, `EnricoMi/publish-unit-test-result-action`
   in `test-results.yml`; everything else is on a major tag, and Dependabot's
   weekly `github-actions` ecosystem bumps them. Do not "normalise" that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -801,8 +801,10 @@ changing any of them.
     a correct narrowing of that opendkim dependency from taking `qshape` down
     on a routine base bump. `tests/test_qshape.py` exists for exactly this.
     `openssl` is named for the same class of reason: `run` uses `openssl pkey`
-    to refuse a DKIM key it cannot read, so the binary is a dependency of the
-    entrypoint rather than of any package the image happens to install.
+    to refuse a DKIM key it cannot read, and `openssl rsa` to rebuild the DNS
+    record for a key restored without its `.txt`, so the binary is a dependency
+    of the entrypoint rather than of any package the image happens to
+    install.
     (commit `2e420c4` named perl, `4a44c60` openssl)
 
 26. **The image has no `ENTRYPOINT`, only `CMD ["/root/run"]`**, which is what

--- a/README.md
+++ b/README.md
@@ -559,6 +559,13 @@ mail._domainkey.smtp.domain.tld. IN	TXT	( "v=DKIM1; h=sha256; k=rsa; "
 	  "j5joTnYwat4387VEUyGUnZ0aZxCERi+ndXv2/wMJ0tizq+a9+EgqIb+7lkUc2XciQPNuTujM25GhrQBEKznvHyPA6fHsFheymOuB763QpkmnQQLCxyLygAY9mE/5RY+5Q6J9oDOQIDAQAB" )  ; ----- DKIM key mail for smtp.domain.tld
 ```
 
+A key restored on its own — a backup that kept the `.private` and not the
+`.txt` — signs just as well, and its record is rebuilt from the key and printed
+with the others rather than going missing at the moment you are looking for it.
+It is printed and not written back, so nothing lands in your volume that you
+did not put there. The rebuild is for RSA keys; an ed25519 key carries its
+public half differently, and the log says so rather than guessing.
+
 Other OpenDKIM options are set with the `OPENDKIM_<name>` variables described in
 [OpenDKIM variables](#opendkim-variables).
 

--- a/README.md
+++ b/README.md
@@ -717,8 +717,11 @@ and sends it unsigned:
 - postfix is running and listening on every `inet` service in `master.cf`, so a
   submission port added with a `POSTFIXMASTER_` variable is checked too;
 - rsyslogd is running, otherwise mail is relayed without a trace;
-- OpenDKIM, PostSRSd and saslauthd are running when the environment asks for
-  them.
+- OpenDKIM, PostSRSd and saslauthd are running when they were asked for. The
+  check sees the container's environment, so a value given through a `_FILE`
+  variable is not in it: for OpenDKIM and PostSRSd it goes by what start-up
+  left on disk instead, and a relay configured that way is covered like any
+  other.
 
 Listening sockets are read from the kernel rather than connected to, so the
 check leaves nothing in the log.

--- a/run
+++ b/run
@@ -243,7 +243,36 @@ dkimConfig()
       echo "$selector._domainkey.$domain $domain:$selector:$privateFile" >> /etc/opendkim/KeyTable
       echo "*@$domain $selector._domainkey.$domain" >> /etc/opendkim/SigningTable
 
-      cat "$txtFile"
+      # opendkim-genkey writes the record beside the key, but only the key is
+      # needed to sign. So a keys volume restored from a backup that kept the
+      # .private and not the .txt comes up signing perfectly and answers "DNS
+      # records:" with a cat error -- at the one moment someone is looking for
+      # the record, which is when they have just restored the key. It is
+      # derivable from the key, so derive it rather than say nothing.
+      #
+      # Printed, not written back: the volume is the user's, and the record is
+      # not state this needs to keep.
+      if [ -f "$txtFile" ] ; then
+        cat "$txtFile"
+      else
+        # Only RSA. opendkim also takes ed25519, whose record carries the raw
+        # public key where this carries the SubjectPublicKeyInfo openssl
+        # prints, so one derivation does not serve both. The flags either side
+        # of "p=" are the ones opendkim-genkey writes in this image rather than
+        # anything read out of the key; tests/test_dkim.py pins that by
+        # comparing the two records.
+        publicKey=$(openssl rsa -in "$privateFile" -pubout -outform DER 2> /dev/null | base64 -w0)
+        if [ -n "$publicKey" ] ; then
+          printf '%s._domainkey.%s.\tIN\tTXT\t( "v=DKIM1; h=sha256; k=rsa; "\n' \
+                 "$selector" "$domain"
+          printf '\t  "p=%s" )  ; ----- DKIM key %s for %s, rebuilt from the private key\n' \
+                 "$publicKey" "$selector" "$domain"
+        else
+          echo "There is no $txtFile beside the key and the record cannot be" \
+               "rebuilt from it, which only works for an RSA key. Signing is" \
+               "unaffected; what is missing is the record to publish." >&2
+        fi
+      fi
     done
 }
 

--- a/tests/test_dkim.py
+++ b/tests/test_dkim.py
@@ -379,6 +379,43 @@ def test_a_key_brought_from_somewhere_else_is_used_as_it_is(postfix_factory, mai
     assert verifies(raw, dkim_dns_record(relay, 'example.com', 'sel1'))
 
 
+def test_a_key_without_its_record_file_still_says_what_to_publish(postfix_factory, mailpit,
+                                                                  generated_keypair):
+    """A restore that kept the .private and not the .txt is not left guessing.
+
+    Only the key is needed to sign, so such a relay comes up signing correctly
+    and reports healthy. What it used to put under "DNS records:" was the shell's
+    "No such file or directory" -- at the one moment someone is looking for the
+    record, which is when they have just restored the key. It is rebuilt from
+    the key instead.
+    """
+    private, text = generated_keypair
+
+    relay = postfix_factory(env=SIGNING, files={KEY_PATH: private})
+    log = container_log(relay)
+
+    # On stderr, which is where the shell put it: container_log is stdout only,
+    # so asserting this against the log would be an assertion that cannot fail.
+    assert 'No such file or directory' not in container_stderr(relay)
+
+    # Taken from the record's own lines and not from the whole log: rsyslogd's
+    # start-up line carries quoted attributes of its own, which a search for
+    # every quoted chunk would collect as well.
+    printed = [line for line in log.splitlines()
+               if '_domainkey' in line or line.lstrip().startswith('"p=')]
+    rebuilt = "".join(re.findall(r'"([^"]*)"', "\n".join(printed)))
+
+    # The same record opendkim-genkey wrote for this key. Joined rather than
+    # compared line by line, because the two are chunked differently and what a
+    # resolver hands a verifier is the concatenation.
+    assert rebuilt == "".join(re.findall(r'"([^"]*)"', text))
+
+    send(relay, sender='sender@example.com', subject='signed by a restored key')
+    raw = mailpit.raw(mailpit.wait_for_message('signed by a restored key')['ID'])
+
+    assert verifies(raw, rebuilt)
+
+
 def test_a_signed_message_still_verifies_after_its_envelope_is_rewritten(
         postfix_shared, mailpit):
     """DKIM and SRS turned on together, which is what a forwarder runs.


### PR DESCRIPTION
Rebased onto current master (`3142aa5`, after #371). **Two commits**, neither of which had a pull request yet:

### `Give every job a timeout, and say what the health check goes by`

Three of the thirteen jobs in this repository carried no `timeout-minutes`, so a hang in any of them ran to GitHub's default of six hours: **Build Image** in `ci.yml` (a required check, and the one every job on master's publication path declares `needs: docker` on), **Test Results** in `test-results.yml`, and `auto-merge` in `dependabot-auto-merge.yml`. Given 45 (the same budget `test.yml` already gives one emulated architecture build; this builds two and pushes them — 35s measured on the master run of `5733464`), 10 (measured 17-51s over its last five runs), and 5 (two API calls) respectively.

Separately, the README's health check section said OpenDKIM/PostSRSd/saslauthd are checked "when the environment asks for them" — but the check only sees the container's environment, never a value resolved from a `_FILE` variable, which is exactly why `healthcheck` falls back to on-disk artefacts for the first two. Someone configuring DKIM through `OPENDKIM_DOMAINS_FILE` was told their relay isn't covered, when it is.

### `Rebuild the DKIM record for a key restored without its .txt`

`opendkim-genkey` writes two files beside each other and only one is needed to sign. A keys volume restored from a backup that kept the `.private` and not the `.txt` comes up signing perfectly and reporting healthy, and answers `DNS records:` with `cat: ... No such file or directory` — at the exact moment someone is looking for that record.

The record is derivable from the key: measured against a key the image generated itself, `openssl rsa -pubout -outform DER | base64 -w0` is byte for byte the `p=` `opendkim-genkey` wrote. Rebuilt for RSA (the only kind `openssl rsa` parses; ed25519 says so on stderr rather than guessing), printed rather than written back (the volume is the user's), with a test that mounts a key with no `.txt`, asserts the rebuilt record matches genkey's own, and verifies a real signed message against it.

### Verification

- full suite on the built image, after rebasing onto `3142aa5`: **254 passed, 2 skipped** (both skips self-explaining: no IPv6 stack on the docker network, and release 1.2.17 predating postsrsd)
- `ruff check --no-cache --select F,B tests` and `shellcheck -S error run healthcheck .claude/hooks/session-start.sh` — clean
- all six workflow files parse; every job now reports a `timeout-minutes` (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
