### PR TITLE
Clear a stale mailbox lock a killed container left behind

### DIFF
--- a/run
+++ b/run
@@ -342,6 +342,15 @@ rm -f \
   /run/rsyslogd.pid \
   /var/spool/postfix/pid/master.pid
 
+# local(8) dot-locks a mailbox for the append (mailbox_delivery_lock defaults
+# to "fcntl, dotlock"), and a container killed mid-delivery leaves that lock
+# on disk with nothing left running to hold it. Postfix's own retries never
+# clear it -- the lock is per mailbox, not per message, so every later
+# delivery to that recipient fails with "unable to create lock file ... File
+# exists" and stays deferred, for ever. This runs before postfix starts, so
+# nothing can be holding one legitimately yet.
+rm -f /var/mail/*.lock
+
 # A queue mounted from a host directory hides /var/spool/postfix/dev, which
 # ships in the image, empty, and is where rsyslog opens the log socket the
 # chrooted postfix daemons write to. Nothing else recreates it: it has no entry

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -115,12 +115,50 @@ def test_local_mailboxes_are_not_taken_over(postfix_factory):
     wait_for_file(relay, '/var/mail/root', 'Subject: local delivery')
     assert container_exec(relay, ["stat", "-c", "%U:%G", "/var/mail/root"]).strip() == 'root:mail'
 
+    # local(8) appends before it releases the mailbox's dotlock, so the file
+    # already holds the text a moment before the delivery agent has finished
+    # and logged "status=sent". Restarting in that window can catch local(8)
+    # mid-delivery -- issue #372 was found from exactly that race, on a run
+    # unrelated to this test. Waiting for the log line closes it.
+    wait_for_log(relay, 'status=sent')
+
     restart(relay)
 
     send(relay, recipients=('root@localhost',), subject='local delivery after restart')
 
     wait_for_file(relay, '/var/mail/root', 'Subject: local delivery after restart')
     assert container_exec(relay, ["stat", "-c", "%U:%G", "/var/mail/root"]).strip() == 'root:mail'
+
+
+def test_a_stale_mailbox_lock_from_an_unclean_stop_is_cleared(postfix_factory):
+    """A container killed mid local-delivery leaves a dotlock local(8) never
+    revisits, which wedges that mailbox for good (issue #372).
+
+    mailbox_delivery_lock defaults to "fcntl, dotlock": local(8) locks the
+    mailbox for the append and removes the lock when it is done. Simulating
+    the file a kill leaves behind, rather than timing an actual kill, is what
+    makes the reproduction reliable rather than racy.
+    """
+    relay = postfix_factory()
+
+    # There is nothing racy to reproduce here: the lock is what a killed
+    # local(8) would have left, whether or not a mailbox already exists.
+    container_exec(relay, ["touch", "/var/mail/root.lock"])
+
+    send(relay, recipients=('root@localhost',), subject='blocked by a stale lock')
+    wait_for_log(relay, 'unable to create lock file')
+
+    # A restart alone does not retry a deferred message -- postfix's own
+    # backoff does that on its own schedule (minimal_backoff_time, 300s by
+    # default), which is not something worth waiting out here. Forcing it is
+    # what "postqueue -f" is for, and what the two tests above already do for
+    # the same reason: what is under test is whether the retry can now
+    # succeed, not when postfix would otherwise have made it.
+    restart(relay)
+    container_exec(relay, ["postqueue", "-f"])
+
+    wait_for_file(relay, '/var/mail/root', 'Subject: blocked by a stale lock')
+    assert 'Mail queue is empty' in container_exec(relay, ["mailq"])
 
 
 def test_mail_waits_in_the_queue_until_the_relayhost_answers(postfix_factory,


### PR DESCRIPTION
Rebased onto current master (`eccdaa0`, after #373 merged). Fixes #372.

### The bug

`local(8)` dot-locks a mailbox for the append (`mailbox_delivery_lock` defaults to `fcntl, dotlock`) and removes the lock when delivery is done. A container killed mid local-delivery — `docker stop`'s default ten-second grace period is not long enough to guarantee it finishes — leaves that lock on disk with nothing left running to hold it.

Nothing ever clears it. The lock is per mailbox, not per message, so every later delivery to that recipient fails the same way and stays deferred **forever**:

```
cannot update mailbox /var/mail/root for user root. unable to create lock file /var/mail/root.lock: File exists
```

Reproduced directly on the built image: touching `/var/mail/root.lock` before a delivery reproduces exactly that log line and an indefinitely deferred queue entry; removing the lock and forcing a retry (`postqueue -f`) then delivers it. `mydestination=localhost` is the default, so local delivery to `root` — reached by `POSTMASTER_ADDRESS` until it is set, or by anything a client addresses without a domain — is on the path by default, not an opt-in.

### The fix

`run` already clears the equivalent class of leftover for the four pid files a kill can leave, in the block immediately above this one, before postfix starts. This is one line more of the same idea for a leftover that block never covered:

```sh
rm -f /var/mail/*.lock
```

Nothing can be holding one legitimately at that point, and a mailbox that was never locked simply glob-expands to nothing.

### Two tests

- **New**: reproduces the defect directly (touching the lock rather than timing a kill, which is what makes it reliable) and was checked by removing the `rm -f` — it fails on the same deferred `File exists` it was written to close, so it is not a false pass. It forces the retry with `postqueue -f` after restart rather than waiting for postfix's own backoff (`minimal_backoff_time`, 300s by default), matching what `test_mail_waits_in_the_queue_until_the_relayhost_answers` and `test_the_queue_survives_replacing_the_container` already do for the same reason.
- **Fixed**: `test_local_mailboxes_are_not_taken_over` is where this was found — it failed once on the `Pytest` job of #371, a pull request whose diff is one line of `.gitignore`. `wait_for_file` returns as soon as `local(8)`'s append is visible, which is a moment before the delivery is finished and the lock released, so `restart()` could land inside that window. Waiting for `status=sent` first closes it, and does not touch what the test was written to assert.

### Verification

- full suite on the built image: **255 passed, 2 skipped** (both skips unrelated and self-explaining: no IPv6 stack on the docker network, and release 1.2.17 predating postsrsd)
- mutation-proved: without `rm -f /var/mail/*.lock`, the new test fails on the exact deferred `File exists` line it exists to catch
- `shellcheck -S error run healthcheck .claude/hooks/session-start.sh` and `ruff check --no-cache --select F,B tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
