### PR TITLE
Refuse a comma in OPENDKIM_DOMAINS instead of signing under the wrong name

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,11 @@ domain you're sending from.
 To enable [DKIM](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail),
 specify a whitespace-separated list of domains in the environment variable
 `OPENDKIM_DOMAINS`. The default DKIM selector is "mail", but can be changed to
-"`<selector>`" using the syntax `OPENDKIM_DOMAINS=<domain>=<selector>`.
+"`<selector>`" using the syntax `OPENDKIM_DOMAINS=<domain>=<selector>`. Not
+comma-separated, unlike `POSTFIX_mynetworks` or
+`POSTSRSD_SRS_EXCLUDE_DOMAINS` above — a comma is an ordinary character in a
+domain name, and an entry containing one is refused rather than signed for
+under the wrong name.
 
 At container start, RSA key pairs will be generated for each domain unless the
 file `/etc/opendkim/keys/<domain>/<selector>.private` exists.
@@ -543,9 +547,10 @@ file `/etc/opendkim/keys/<domain>/<selector>.private` exists.
 Signing that was asked for and cannot happen stops the container rather than
 being skipped, so a relay never quietly sends unsigned mail on your behalf.
 It exits with a message on stderr if a key has to be generated and cannot be
-written — a read-only `/etc/opendkim/keys` is the usual reason — or if a key
+written — a read-only `/etc/opendkim/keys` is the usual reason — if a key
 that is already there cannot be read as a private key, which is what an empty
-or truncated file looks like. If you want the
+or truncated file looks like — or if an entry in `OPENDKIM_DOMAINS` contains a
+comma. If you want the
 keys to persist indefinitely, make sure to mount a volume for
 `/etc/opendkim/keys`, otherwise they will be destroyed when the container is
 removed.

--- a/run
+++ b/run
@@ -189,6 +189,26 @@ dkimConfig()
 
     echo "DNS records:"
     for d in $OPENDKIM_DOMAINS ; do
+      # A comma is an ordinary character in a domain name to this parsing,
+      # which splits OPENDKIM_DOMAINS on whitespace and nothing else. Every
+      # other comma-separated variable this image reads -- POSTFIX_mynetworks,
+      # POSTSRSD_SRS_EXCLUDE_DOMAINS -- makes a comma here a plausible typo
+      # rather than a plausible domain, and the loop below has no way to tell
+      # the two apart: it would generate a key, print a record nobody can
+      # publish, and write a signing rule no sender matches, all while opendkim
+      # starts and the health check calls the relay healthy. Refusing it here
+      # is the same choice run already makes for a daemon that did not start,
+      # a POSTSRSD_SRS_DOMAIN this build cannot honour, or a secret it cannot
+      # read: loud now, rather than a relay that signs nothing and says
+      # nothing about it.
+      if [[ "$d" == *,* ]] ; then
+        echo "OPENDKIM_DOMAINS entry '$d' contains a comma, which" \
+             "OPENDKIM_DOMAINS does not use as a separator -- it is" \
+             "whitespace-separated. Refusing to relay with a domain list" \
+             "that would silently sign for the wrong name." >&2
+        exit 1
+      fi
+
       domain=$(echo "$d"| cut -f1 -d '=')
       selector=$(expr match "$d" '.*\=\(.*\)')
       if [ -z "$selector" ] ; then

--- a/tests/test_dkim.py
+++ b/tests/test_dkim.py
@@ -353,6 +353,27 @@ def test_the_domain_list_may_be_written_over_several_lines(postfix_shared):
         ['sel2.private', 'sel2.txt']
 
 
+def test_a_comma_in_the_domain_list_is_refused(postfix_factory):
+    """OPENDKIM_DOMAINS is whitespace-separated, and a comma is an ordinary
+    character in a domain name to the parsing that reads it (issue #340).
+
+    Two of this image's other list variables -- POSTFIX_mynetworks,
+    POSTSRSD_SRS_EXCLUDE_DOMAINS -- are comma-separated, which is what makes a
+    comma here a plausible typo rather than a plausible domain. Left alone, it
+    would generate a key for a name nobody can publish a record for, sign for
+    it, and match no sender -- DKIM silently off on a relay that reports
+    healthy the whole time. Refusing it loudly is the same choice run already
+    makes for a key it could not generate or read.
+    """
+    relay = postfix_factory(
+        env={'OPENDKIM_DOMAINS': 'first.example,second.example'},
+        wait_ready=False)
+
+    assert exit_code_within(relay, seconds=20) == 1
+    assert 'first.example,second.example' in container_stderr(relay)
+    assert 'comma' in container_stderr(relay)
+
+
 def test_a_key_brought_from_somewhere_else_is_used_as_it_is(postfix_factory, mailpit,
                                                             generated_keypair):
     """Moving a relay must not mean republishing the DNS records.


### PR DESCRIPTION
Rebased onto current master (`966d15c`, after #374 merged). Fixes #340.

### The bug

`OPENDKIM_DOMAINS` is split on whitespace and nothing else, so a comma is an ordinary character in a domain name to this parsing. Two other list variables this image reads are comma-separated — `POSTFIX_mynetworks`, `POSTSRSD_SRS_EXCLUDE_DOMAINS` — which is what makes a comma here a plausible typo rather than a plausible domain: a compose file that already has one of those is exactly where the second domain gets added to `OPENDKIM_DOMAINS` the same way.

Left alone, `OPENDKIM_DOMAINS=first.example,second.example` reads as one domain called `first.example,second.example`: a key is generated for it, a DNS record nobody can publish is printed at start-up, and a signing rule no sender can ever match is written. Every message then leaves unsigned. `first.example=sel1,second.example` is the quieter form of the same mistake — `cut` and `expr` are greedy in opposite directions, so the relay signs `first.example` with `sel2` and `second.example` disappears without a word, self-consistently enough that a user who checked one domain would find it working.

Nothing catches it. A directory with a comma in its name is legal, so the key generates and is readable; neither table is malformed as table syntax, so opendkim starts; `healthcheck` asks only whether `OPENDKIM_DOMAINS` is set and opendkim is running, and both hold. The relay reports **healthy** throughout, and the failure surfaces only at the receiving end.

### The fix

That silent failure is out of keeping with the rest of the script, which refuses to run rather than run wrongly — a daemon that did not start, a `POSTSRSD_SRS_DOMAIN` this build cannot honour, a `_FILE` it cannot read, a key it could not generate or could not read. This is the same choice: refuse an entry containing a comma, naming it and exiting 1, before anything is generated.

Accepting comma as an additional separator was the other option the issue lays out, and is deliberately not this commit: it would change what the README documents (`OPENDKIM_DOMAINS` is whitespace-separated), still leaves nothing validating what survives the split against actually being a domain, and a container that starts happens to be *less* loud than one that refuses for a value that was wrong either way. Refusing is the narrower change and the one every other guard in this script already made.

### The test

New in `tests/test_dkim.py`, next to the other `OPENDKIM_DOMAINS` parsing cases, asserting the container exits 1 with a message naming the offending entry. Checked by removing the guard: the container comes up, generates `/etc/opendkim/keys/first.example,second.example/mail.private` and prints its record, and the test fails on `assert None == 1` — `exit_code_within` found nothing to report because nothing had stopped. There was no test exercising a comma before this; the list is exercised with a space, a newline and a trailing `=`, never a comma.

README gains one sentence in each of the two paragraphs this touches: that the list is not comma-separated like its neighbours, and that a comma is now one more reason the container refuses to start.

### Verification

- full suite on the built image: **256 passed, 2 skipped** (both skips unrelated and self-explaining: no IPv6 stack on the docker network, and release 1.2.17 predating postsrsd)
- mutation-proved: without the guard, the new test fails with the exact "nothing stopped" symptom it exists to catch
- `shellcheck -S error run healthcheck .claude/hooks/session-start.sh` and `ruff check --no-cache --select F,B tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFvW48XysVq8g5W3F22vc7
